### PR TITLE
43 sampler create logic for tokenizer signature task

### DIFF
--- a/apps/python/sampler/activities/lmeh/sample.py
+++ b/apps/python/sampler/activities/lmeh/sample.py
@@ -32,7 +32,7 @@ async def lmeh_sample(args: PocketNetworkTaskRequest) -> bool:
     # START: POCKET NETWORK CODE
     ############################################################
     config = get_app_config()['config']
-    eval_logger.debug(f"Starting activity sample:", task_name=args.tasks, address=args.requester_args.address,
+    eval_logger.debug(f"Starting activity lmeh_sample:", wf_id=wf_id, task_name=args.tasks, address=args.requester_args.address,
                         blacklist=args.blacklist, qty=args.qty)
     args.postgres_uri = config["postgres_uri"]
     args.mongodb_uri = config["mongodb_uri"]

--- a/apps/python/sampler/activities/lmeh/sample.py
+++ b/apps/python/sampler/activities/lmeh/sample.py
@@ -23,7 +23,7 @@ from activities.utils import auto_heartbeater
 
 @activity.defn
 @auto_heartbeater
-async def sample(args: PocketNetworkTaskRequest) -> bool:
+async def lmeh_sample(args: PocketNetworkTaskRequest) -> bool:
     app_config = get_app_config()
     eval_logger = get_app_logger("sample")
 

--- a/apps/python/sampler/activities/lmeh/utils/generator.py
+++ b/apps/python/sampler/activities/lmeh/utils/generator.py
@@ -225,7 +225,6 @@ def genererate_requests(
         # Task
         task = task_output.task
         instances = task.instances
-
         task_mongodb = PocketNetworkMongoDBTask(**{
             **args.model_dump(),
             **{"total_instances": len(instances),
@@ -241,8 +240,8 @@ def genererate_requests(
                 instance_id = instance_mongo['_id']
                 data = pocket_req.model_dump_json(exclude_defaults=True)
                 prompt_mongo = PocketNetworkMongoDBPrompt(data=data, task_id=task_mongodb.id, instance_id=instance_id)
-                insert_mongo_prompt.append(prompt_mongo.model_dump())
-                eval_logger.debug(f"Data:", PocketNetworkMongoDBPrompt=prompt_mongo)
+                insert_mongo_prompt.append(prompt_mongo.model_dump(by_alias=True))
+                eval_logger.debug(f"Prompt:", PocketNetworkMongoDBPrompt=prompt_mongo)
     try:
         with mongo_client.start_session() as session:
             with session.start_transaction():

--- a/apps/python/sampler/activities/lmeh/utils/generator.py
+++ b/apps/python/sampler/activities/lmeh/utils/generator.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 from temporalio.exceptions import ApplicationError
 from activities.lmeh.utils import mongodb as lmeh_mongodb
 from activities.lmeh.utils.pocket_lm_eval.tasks import PocketNetworkTaskManager
-from protocol.protocol import PocketNetworkTaskRequest, PocketNetworkMongoDBTask, PromptMongoDB
+from protocol.protocol import PocketNetworkTaskRequest, PocketNetworkMongoDBTask, PocketNetworkMongoDBPrompt
 from pymongo import MongoClient
 
 
@@ -240,9 +240,9 @@ def genererate_requests(
             for pocket_req in instance.resps:
                 instance_id = instance_mongo['_id']
                 data = pocket_req.model_dump_json(exclude_defaults=True)
-                prompt_mongo = PromptMongoDB(data=data, task_id=task_mongodb.id, instance_id=instance_id)
+                prompt_mongo = PocketNetworkMongoDBPrompt(data=data, task_id=task_mongodb.id, instance_id=instance_id)
                 insert_mongo_prompt.append(prompt_mongo.model_dump())
-                eval_logger.debug(f"Data:", PromptMongoDB=prompt_mongo)
+                eval_logger.debug(f"Data:", PocketNetworkMongoDBPrompt=prompt_mongo)
     try:
         with mongo_client.start_session() as session:
             with session.start_transaction():

--- a/apps/python/sampler/activities/lmeh/utils/mongodb.py
+++ b/apps/python/sampler/activities/lmeh/utils/mongodb.py
@@ -42,7 +42,7 @@ def reconstruct_instance(_id: str, collection: pymongo.collection.Collection):
     
     return instance
 
-
+# TODO : This should reffer to PocketNetworkMongoDBInstance and not depend on LMEH blindly
 def instance_to_dict(instance: Instance, task_id: ObjectId)-> dict:
     instance_mongo = asdict(instance)
     instance_mongo.pop('resps', None)

--- a/apps/python/sampler/activities/signatures/signatures.py
+++ b/apps/python/sampler/activities/signatures/signatures.py
@@ -1,0 +1,83 @@
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+from app.app import get_app_logger, get_app_config
+
+import os
+import sys
+
+# add file path to sys.path
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+# Custom modules
+from protocol.protocol import PocketNetworkTaskRequest
+from activities.signatures.tokenizer import get_tokenizer_task
+from activities.utils import auto_heartbeater
+
+
+@activity.defn
+@auto_heartbeater
+async def sample(args: PocketNetworkTaskRequest) -> bool:
+
+    ############################################################
+    # Config App
+    ############################################################
+    app_config = get_app_config()
+    eval_logger = get_app_logger("sampling signatures")
+
+    wf_id = activity.info().workflow_id
+    
+    config = get_app_config()['config']
+    eval_logger.debug(f"Starting activity sample signatures:", task_name=args.tasks, address=args.requester_args.address,
+                        blacklist=args.blacklist, qty=args.qty)
+    args.mongodb_uri = config["mongodb_uri"]
+    mongo_client = config["mongo_client"]
+    try:
+        # The ping command is cheap and does not require auth.
+        mongo_client.admin.command('ping')
+    except Exception as e:
+        eval_logger.error(f"Mongo DB connection failed.")
+        raise ApplicationError("Mongo DB connection failed.", non_retryable=True)
+    if args.llm_args is None:
+        args.llm_args = {}
+
+    ############################################################
+    # Gather all tasks
+    ############################################################
+    if args.tasks == 'tokenizer':
+        eval_logger.debug(f"starting tokenizer task sample")
+        eval_task, eval_instances, eval_prompts = get_tokenizer_task(args.requester_args)
+        
+    else:
+        eval_logger.error(f"requested task {args.tasks} is not supported")
+        return False
+
+    ############################################################
+    # Insert into Mongo
+    ############################################################
+    
+    insert_mongo_prompt = []
+    insert_mongo_tasks = []
+    insert_mongo_instances = []
+    insert_mongo_tasks.append(eval_task.model_dump(by_alias=True))
+    # Instances
+    for instance_mongo in eval_instances:
+        insert_mongo_instances.append(instance_mongo)
+        eval_logger.debug(f"Instance:", instance=instance_mongo)
+        # Prompts
+        for prompt_mongo in eval_prompts:
+            insert_mongo_prompt.append(prompt_mongo.model_dump())
+            eval_logger.debug(f"Data:", PocketNetworkMongoDBPrompt=prompt_mongo)
+    try:
+        with mongo_client.start_session() as session:
+            with session.start_transaction():
+                mongo_client['pocket-ml-testbench']['tasks'].insert_many(insert_mongo_tasks, ordered=False,
+                                                                         session=session)
+                mongo_client['pocket-ml-testbench']['instances'].insert_many(insert_mongo_instances, ordered=False,
+                                                                             session=session)
+                mongo_client['pocket-ml-testbench']['prompts'].insert_many(insert_mongo_prompt, ordered=False,
+                                                                           session=session)
+                eval_logger.debug("Instances saved to MongoDB successfully.")
+    except Exception as e:
+        eval_logger.error("Failed to save Instances to MongoDB.")
+        raise ApplicationError("Failed to save instances to MongoDB.", error=e, non_retryable=True)
+
+    return True

--- a/apps/python/sampler/activities/signatures/signatures.py
+++ b/apps/python/sampler/activities/signatures/signatures.py
@@ -1,21 +1,22 @@
-from temporalio import activity
-from temporalio.exceptions import ApplicationError
-from app.app import get_app_logger, get_app_config
-
 import os
 import sys
 
+from app.app import get_app_config, get_app_logger
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+
 # add file path to sys.path
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+from activities.signatures.tokenizer.tokenizer import get_tokenizer_task
+from activities.utils import auto_heartbeater
+
 # Custom modules
 from protocol.protocol import PocketNetworkTaskRequest
-from activities.signatures.tokenizer import get_tokenizer_task
-from activities.utils import auto_heartbeater
 
 
 @activity.defn
 @auto_heartbeater
-async def sample(args: PocketNetworkTaskRequest) -> bool:
+async def sign_sample(args: PocketNetworkTaskRequest) -> bool:
 
     ############################################################
     # Config App
@@ -24,15 +25,20 @@ async def sample(args: PocketNetworkTaskRequest) -> bool:
     eval_logger = get_app_logger("sampling signatures")
 
     wf_id = activity.info().workflow_id
-    
-    config = get_app_config()['config']
-    eval_logger.debug(f"Starting activity sample signatures:", task_name=args.tasks, address=args.requester_args.address,
-                        blacklist=args.blacklist, qty=args.qty)
+
+    config = get_app_config()["config"]
+    eval_logger.debug(
+        f"Starting activity sample signatures:",
+        task_name=args.tasks,
+        address=args.requester_args.address,
+        blacklist=args.blacklist,
+        qty=args.qty,
+    )
     args.mongodb_uri = config["mongodb_uri"]
     mongo_client = config["mongo_client"]
     try:
         # The ping command is cheap and does not require auth.
-        mongo_client.admin.command('ping')
+        mongo_client.admin.command("ping")
     except Exception as e:
         eval_logger.error(f"Mongo DB connection failed.")
         raise ApplicationError("Mongo DB connection failed.", non_retryable=True)
@@ -42,10 +48,10 @@ async def sample(args: PocketNetworkTaskRequest) -> bool:
     ############################################################
     # Gather all tasks
     ############################################################
-    if args.tasks == 'tokenizer':
+    if args.tasks == "tokenizer":
         eval_logger.debug(f"starting tokenizer task sample")
         eval_task, eval_instances, eval_prompts = get_tokenizer_task(args.requester_args)
-        
+
     else:
         eval_logger.error(f"requested task {args.tasks} is not supported")
         return False
@@ -53,31 +59,34 @@ async def sample(args: PocketNetworkTaskRequest) -> bool:
     ############################################################
     # Insert into Mongo
     ############################################################
-    
+
     insert_mongo_prompt = []
     insert_mongo_tasks = []
     insert_mongo_instances = []
     insert_mongo_tasks.append(eval_task.model_dump(by_alias=True))
     # Instances
     for instance_mongo in eval_instances:
-        insert_mongo_instances.append(instance_mongo)
+        insert_mongo_instances.append(instance_mongo.model_dump(by_alias=True))
         eval_logger.debug(f"Instance:", instance=instance_mongo)
         # Prompts
         for prompt_mongo in eval_prompts:
-            insert_mongo_prompt.append(prompt_mongo.model_dump())
+            insert_mongo_prompt.append(prompt_mongo.model_dump(by_alias=True))
             eval_logger.debug(f"Data:", PocketNetworkMongoDBPrompt=prompt_mongo)
     try:
         with mongo_client.start_session() as session:
             with session.start_transaction():
-                mongo_client['pocket-ml-testbench']['tasks'].insert_many(insert_mongo_tasks, ordered=False,
-                                                                         session=session)
-                mongo_client['pocket-ml-testbench']['instances'].insert_many(insert_mongo_instances, ordered=False,
-                                                                             session=session)
-                mongo_client['pocket-ml-testbench']['prompts'].insert_many(insert_mongo_prompt, ordered=False,
-                                                                           session=session)
+                mongo_client["pocket-ml-testbench"]["tasks"].insert_many(
+                    insert_mongo_tasks, ordered=False, session=session
+                )
+                mongo_client["pocket-ml-testbench"]["instances"].insert_many(
+                    insert_mongo_instances, ordered=False, session=session
+                )
+                mongo_client["pocket-ml-testbench"]["prompts"].insert_many(
+                    insert_mongo_prompt, ordered=False, session=session
+                )
                 eval_logger.debug("Instances saved to MongoDB successfully.")
     except Exception as e:
         eval_logger.error("Failed to save Instances to MongoDB.")
-        raise ApplicationError("Failed to save instances to MongoDB.", error=e, non_retryable=True)
+        raise ApplicationError("Failed to save instances to MongoDB.", non_retryable=True)
 
     return True

--- a/apps/python/sampler/activities/signatures/tokenizer/tokenizer.py
+++ b/apps/python/sampler/activities/signatures/tokenizer/tokenizer.py
@@ -1,38 +1,37 @@
-from protocol.protocol import PocketNetworkTaskRequest, RequesterArgs, PocketNetworkMongoDBTask, PocketNetworkMongoDBInstance, PocketNetworkMongoDBPrompt
 from typing import TYPE_CHECKING, List, Optional, Union
+
+from protocol.protocol import (
+    PocketNetworkMongoDBInstance,
+    PocketNetworkMongoDBPrompt,
+    PocketNetworkMongoDBTask,
+    PocketNetworkTaskRequest,
+    RequesterArgs,
+)
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
-def get_tokenizer_task(args: RequesterArgs) -> tuple[PocketNetworkMongoDBTask, List[PocketNetworkMongoDBInstance], List[PocketNetworkMongoDBPrompt]] :
+def get_tokenizer_task(
+    args: RequesterArgs,
+) -> tuple[PocketNetworkMongoDBTask, List[PocketNetworkMongoDBInstance], List[PocketNetworkMongoDBPrompt]]:
 
     # Set call variables
     args.method = "GET"
     args.path = "/pokt/tokenizer"
-    args.headers = ""
+    args.headers = {}
 
     # Create task
     task = PocketNetworkMongoDBTask(
-        framework = "signatures",
-        requester_args = args,
-        blacklist = [],
-        qty = 1, # Tokenizer is hardcoded to this, no point in asking twice
-        tasks = 'tokenizer',
-        total_instances = 1,
-        request_type = '', # Remove 
+        framework="signatures",
+        requester_args=args,
+        blacklist=[],
+        qty=1,  # Tokenizer is hardcoded to this, no point in asking twice
+        tasks="tokenizer",
+        total_instances=1,
+        request_type="",  # Remove
     )
-
     # There is a single instance for getting the tokenizer
-    instance = PocketNetworkMongoDBInstance(
-        task_id = task.id
-    )
-
+    instance = PocketNetworkMongoDBInstance(task_id=task.id)
     # Create the void prompt
-    prompt = PocketNetworkMongoDBPrompt(
-        model_config = {},
-        data = '',
-        task_id = task.id,
-        instance_id = instance.id,
-        timeout = 10
-    )
-    
+    prompt = PocketNetworkMongoDBPrompt(model_config={}, data="", task_id=task.id, instance_id=instance.id, timeout=10)
+
     return task, [instance], [prompt]

--- a/apps/python/sampler/activities/signatures/tokenizer/tokenizer.py
+++ b/apps/python/sampler/activities/signatures/tokenizer/tokenizer.py
@@ -1,0 +1,38 @@
+from protocol.protocol import PocketNetworkTaskRequest, RequesterArgs, PocketNetworkMongoDBTask, PocketNetworkMongoDBInstance, PocketNetworkMongoDBPrompt
+from typing import TYPE_CHECKING, List, Optional, Union
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+def get_tokenizer_task(args: RequesterArgs) -> tuple[PocketNetworkMongoDBTask, List[PocketNetworkMongoDBInstance], List[PocketNetworkMongoDBPrompt]] :
+
+    # Set call variables
+    args.method = "GET"
+    args.path = "/pokt/tokenizer"
+    args.headers = ""
+
+    # Create task
+    task = PocketNetworkMongoDBTask(
+        framework = "signatures",
+        requester_args = args,
+        blacklist = [],
+        qty = 1, # Tokenizer is hardcoded to this, no point in asking twice
+        tasks = 'tokenizer',
+        total_instances = 1,
+        request_type = '', # Remove 
+    )
+
+    # There is a single instance for getting the tokenizer
+    instance = PocketNetworkMongoDBInstance(
+        task_id = task.id
+    )
+
+    # Create the void prompt
+    prompt = PocketNetworkMongoDBPrompt(
+        model_config = {},
+        data = '',
+        task_id = task.id,
+        instance_id = instance.id,
+        timeout = 10
+    )
+    
+    return task, [instance], [prompt]

--- a/apps/python/sampler/activities/signatures/tokenizer/tokenizer.py
+++ b/apps/python/sampler/activities/signatures/tokenizer/tokenizer.py
@@ -1,14 +1,11 @@
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import List
 
 from protocol.protocol import (
     PocketNetworkMongoDBInstance,
     PocketNetworkMongoDBPrompt,
     PocketNetworkMongoDBTask,
-    PocketNetworkTaskRequest,
     RequesterArgs,
 )
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-
 
 def get_tokenizer_task(
     args: RequesterArgs,

--- a/apps/python/sampler/protocol/protocol.py
+++ b/apps/python/sampler/protocol/protocol.py
@@ -1,15 +1,18 @@
-#import torch
-from typing import List, Literal, Optional, Union, Dict
+# import torch
+from typing import Dict, List, Literal, Optional, Union
+
 from bson import ObjectId
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+
 class PocketNetworkRegisterTaskRequest(BaseModel):
-    framework: Literal["lmeh", "helm"]
+    framework: str
     tasks: str
     verbosity: Optional[Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]] = "ERROR"
     include_path: Optional[str] = None
     postgres_uri: Optional[str] = None
     mongodb_uri: Optional[str] = None
+
 
 class RequesterArgs(BaseModel):
     address: str
@@ -18,14 +21,15 @@ class RequesterArgs(BaseModel):
     path: str = "/v1/completions"
     headers: Optional[Dict] = {"Content-Type": "application/json"}
 
+
 class PocketNetworkTaskRequest(PocketNetworkRegisterTaskRequest):
     requester_args: RequesterArgs
     blacklist: Optional[List[int]] = []
     qty: Optional[Union[int, Literal["all"]]] = None
     doc_ids: Optional[List[int]] = None
-    model: Optional[str] = "pocket_network"       
-    llm_args: Optional[Dict] = None                # TODO : Remove: This is LLM specific, move to agnostic format.
-    num_fewshot: Optional[int] = Field(None, ge=0) # TODO : Remove: This is LLM specific, move to agnostic format.
+    model: Optional[str] = "pocket_network"
+    llm_args: Optional[Dict] = None  # TODO : Remove: This is LLM specific, move to agnostic format.
+    num_fewshot: Optional[int] = Field(None, ge=0)  # TODO : Remove: This is LLM specific, move to agnostic format.
 
     @field_validator("qty")
     def check_qty(cls, v):
@@ -47,7 +51,7 @@ class PocketNetworkTaskRequest(PocketNetworkRegisterTaskRequest):
             self.blacklist = []
             self.doc_ids = None
         return self
-    
+
     # TODO: Fix this, problem between pydantic and temporalio
     # @model_validator(mode="after")
     # def verify_blacklist_with_doc_ids(self):
@@ -57,6 +61,7 @@ class PocketNetworkTaskRequest(PocketNetworkRegisterTaskRequest):
 
     # TODO: validate that tasks field is unique in task sense,
 
+
 class PyObjectId(ObjectId):
     @classmethod
     def __get_validators__(cls):
@@ -65,61 +70,63 @@ class PyObjectId(ObjectId):
     @classmethod
     def validate(cls, v):
         if not isinstance(v, ObjectId):
-            raise ValueError('Not a valid ObjectId')
+            raise ValueError("Not a valid ObjectId")
         return str(v)
-    
+
+
 # This class serves a subgroup of prompts, as a task can have many instances
 # and each instance have many prompts. If not all the prompts are finished an
 # instance cannot be finished.
 # The actual record contains many more optional (and variable) fields, but these
 # are mandatory.
 class PocketNetworkMongoDBInstance(BaseModel):
-    _id: Optional[ObjectId] = None
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     done: bool = False
-	# -- Relations Below --
-    task_id: ObjectId 
+    # -- Relations Below --
+    task_id: ObjectId
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class PocketNetworkMongoDBPrompt(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    _id: Optional[ObjectId] = None
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
+    # _id: Optional[ObjectId] = None
     data: str
     task_id: ObjectId
     instance_id: ObjectId
     timeout: int = 20
     done: bool = False
 
-    @model_validator(mode="after")
-    def create_id(cls, values):
-        if "_id" not in values:
-            values._id = ObjectId()
-        return values
-    
+    # @model_validator(mode="after")
+    # def create_id(cls, values):
+    #     if "_id" not in values:
+    #         values._id = ObjectId()
+    #     return values
+
 
 class PocketNetworkMongoDBTask(BaseModel):
-    framework: Literal["lmeh", "helm", "signatures"]
+    framework: str
     requester_args: RequesterArgs
     blacklist: Optional[List[int]] = []
     qty: int
     tasks: str
     total_instances: int
-    request_type: str   # TODO : Remove, specific of LMEH
+    request_type: str  # TODO : Remove, specific of LMEH
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     done: bool = False
 
     class Config:
         populate_by_name = True
-        json_schema_extra = {
-            "example": {
-                "_id": "60d3216d82e029466c6811d2"
-            }
-        }
+        json_schema_extra = {"example": {"_id": "60d3216d82e029466c6811d2"}}
 
 
 ### From vllm/entrypoints/openai/protocol.py
 class OpenAIBaseModel(BaseModel):
     # OpenAI API does not allow extra fields
     model_config = ConfigDict(extra="forbid")
+
 
 class CompletionRequest(OpenAIBaseModel):
     # Ordered by official OpenAI API documentation
@@ -134,9 +141,9 @@ class CompletionRequest(OpenAIBaseModel):
     max_tokens: Optional[int] = 16
     n: int = 1
     presence_penalty: Optional[float] = 0.0
-    seed: Optional[int] = Field(None,
-                                ge=-9223372036854775808, #from torch.iinfo(torch.long).min,
-                                le=9223372036854775807) #from torch.iinfo(torch.long).max)
+    seed: Optional[int] = Field(
+        None, ge=-9223372036854775808, le=9223372036854775807  # from torch.iinfo(torch.long).min,
+    )  # from torch.iinfo(torch.long).max)
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     stream: Optional[bool] = False
     suffix: Optional[str] = None
@@ -151,4 +158,3 @@ class CompletionRequest(OpenAIBaseModel):
                 if field in data:
                     del data[field]
         return data
-

--- a/apps/python/sampler/protocol/protocol.py
+++ b/apps/python/sampler/protocol/protocol.py
@@ -92,19 +92,11 @@ class PocketNetworkMongoDBInstance(BaseModel):
 class PocketNetworkMongoDBPrompt(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
-    # _id: Optional[ObjectId] = None
     data: str
     task_id: ObjectId
     instance_id: ObjectId
     timeout: int = 20
     done: bool = False
-
-    # @model_validator(mode="after")
-    # def create_id(cls, values):
-    #     if "_id" not in values:
-    #         values._id = ObjectId()
-    #     return values
-
 
 class PocketNetworkMongoDBTask(BaseModel):
     framework: str

--- a/apps/python/sampler/worker/main.py
+++ b/apps/python/sampler/worker/main.py
@@ -13,7 +13,8 @@ from app.app import setup_app, get_app_logger
 from app.config import read_config
 
 from activities.lmeh.register_task import register_task as lmeh_register_task
-from activities.lmeh.sample import sample as lmeh_sample
+from activities.lmeh.sample import lmeh_sample as lmeh_sample
+from activities.signatures.signatures import sign_sample as sign_sample
 from workflows.register import Register
 from workflows.sampler import Sampler
 import concurrent.futures
@@ -65,6 +66,7 @@ async def main():
             activities=[
                 lmeh_register_task,
                 lmeh_sample,
+                sign_sample,
             ],
             activity_executor=activity_executor,
             max_concurrent_activities=max_workers,

--- a/apps/python/sampler/workflows/sampler.py
+++ b/apps/python/sampler/workflows/sampler.py
@@ -9,8 +9,8 @@ with workflow.unsafe.imports_passed_through():
     # add this to ensure app config is available on the thread
     from app.app import get_app_logger, get_app_config
     # add any activity that needs to be used on this workflow
-    from activities.lmeh.register_task import register_task as lmeh_register_task
-    from activities.lmeh.sample import sample as lmeh_sample
+    from activities.lmeh.sample import lmeh_sample as lmeh_sample
+    from activities.signatures.signatures import sign_sample as sign_sample
     from pydantic import BaseModel
     from protocol.converter import pydantic_data_converter
 
@@ -26,7 +26,12 @@ class Sampler:
                 start_to_close_timeout=timedelta(seconds=300),
                 retry_policy=RetryPolicy(maximum_attempts=2),
             )
-        if params.framework == "signatures":
-            pass
-
-        raise ApplicationError(f"{params.framework} framework not implemented yet")
+        elif params.framework == "signatures":
+            return await workflow.execute_activity(
+                sign_sample,
+                params,
+                start_to_close_timeout=timedelta(seconds=300),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
+        else:
+            raise ApplicationError(f"{params.framework} framework not implemented yet")

--- a/apps/python/sampler/workflows/sampler.py
+++ b/apps/python/sampler/workflows/sampler.py
@@ -26,5 +26,7 @@ class Sampler:
                 start_to_close_timeout=timedelta(seconds=300),
                 retry_policy=RetryPolicy(maximum_attempts=2),
             )
+        if params.framework == "signatures":
+            pass
 
         raise ApplicationError(f"{params.framework} framework not implemented yet")

--- a/apps/python/sidecar/tokenizers_utils/load.py
+++ b/apps/python/sidecar/tokenizers_utils/load.py
@@ -5,11 +5,7 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Union
 
-from app.app import get_app_logger
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
-
-eval_logger = get_app_logger("sample")
-
 
 def _get_tokenizer_jsons(tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast]) -> dict:
     """Get tokenizer jsons been used"""

--- a/docker-compose/morse-poc/dependencies_configs/temporal/initialize.sh
+++ b/docker-compose/morse-poc/dependencies_configs/temporal/initialize.sh
@@ -41,6 +41,18 @@ for key in "${key_array[@]}"; do
 done
 
 temporal schedule create \
+      --schedule-id "lmeh-tokenizer-00A1" \
+      --workflow-id "lmeh-tokenizer-00A1" \
+      --namespace 'pocket-ml-testbench' \
+      --workflow-type 'Manager' \
+      --task-queue 'manager' \
+      --cron '@every 2m' \
+      --execution-timeout 350 \
+      --task-timeout 175 \
+      --overlap-policy 'BufferOne' \
+      --input "{\"service\":\"00A1\", \"tests\": [{\"framework\": \"signatures\", \"tasks\": [\"tokenizer\"]}]}"
+
+temporal schedule create \
     --schedule-id 'f3abbe313689a603a1a6d6a43330d0440a552288-00A1' \
     --workflow-id 'f3abbe313689a603a1a6d6a43330d0440a552288-00A1' \
     --namespace 'pocket-ml-testbench' \

--- a/docker-compose/morse-poc/pocket_configs/config/chains.json
+++ b/docker-compose/morse-poc/pocket_configs/config/chains.json
@@ -1,6 +1,6 @@
 [
   {
     "id": "00A1",
-    "url": "http://llm-engine:9087"
+    "url": "http://nginx-sidecar:9087"
   }
 ]


### PR DESCRIPTION
Following https://github.com/pokt-scan/pocket-ml-testbench/issues/43 the tokenizer can now  be sampled as a signature.

Some other changes were included:
- Changed `PromptMongoDB` for `PocketNetworkMongoDBPrompt`.
- Added `PocketNetworkMongoDBInstance`.
- Renamed LMEH sampler task to avoid confusion, `sample` was renamed to `lmeh_sample`
- Task requests frameworks are no longer limited to a list of whitelisted strings.
- All `PocketNetworkMongoDB*` now assign the `_id` automatically and using the same approach: `id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")`. Note that model dump should be done with `by_alias=True`