### PR TITLE
61 evalator finish code for lmeh

### DIFF
--- a/apps/go/manager/records/node.go
+++ b/apps/go/manager/records/node.go
@@ -180,7 +180,7 @@ func (record *NodeRecord) AppendTask(framework string, task string, date time.Ti
 
 		newTask := SignatureTaskRecord{
 			TaskData:      baseTaskData,
-			LastSignature: "83332a7f32e4188bb276a18ff78620acfd3c6edbd68002b746bda990ed30d56c",
+			LastSignature: "",
 			Signatures:    make([]SignatureSample, bufferLen),
 			CircBuffer: types.CircularBuffer{
 				CircBufferLen: bufferLen,

--- a/apps/python/evaluator/activities/lmeh/evaluate.py
+++ b/apps/python/evaluator/activities/lmeh/evaluate.py
@@ -171,14 +171,17 @@ async def lmeh_evaluate(args: PocketNetworkEvaluationTaskRequest) -> bool:
                 eval_logger.debug("Generating LM")
                 lm = EvaluatorLM(**args.llm_args)
                 eval_logger.debug("LM generated successfully.")
-                task_output = await lmeh_generator.evaluate(
-                    lm=lm,
-                    task_dict=task_dict,
-                    task_id=args.task_id,
-                    mongo_client=mongo_client,
-                    selected_metrics=open_llm_metrics,
-                    eval_logger=eval_logger,
-                )
-                eval_logger.info("Evaluation completed successfully.")
+                try:
+                    result = await lmeh_generator.evaluate(
+                        lm=lm,
+                        task_dict=task_dict,
+                        task_id=args.task_id,
+                        mongo_client=mongo_client,
+                        selected_metrics=open_llm_metrics,
+                        eval_logger=eval_logger,
+                    )
+                    eval_logger.info("Evaluation completed successfully.")
+                except ApplicationError as e:
+                    raise e
 
-    return True
+    return result

--- a/apps/python/evaluator/activities/lmeh/evaluate.py
+++ b/apps/python/evaluator/activities/lmeh/evaluate.py
@@ -42,6 +42,10 @@ async def lmeh_evaluate(args: PocketNetworkEvaluationTaskRequest) -> bool:
 
     if args.llm_args is None:
         args.llm_args = {}
+    eval_logger.info(
+        "Starting activity lmeh_evaluate",
+        task_id = str(args.task_id),
+    )
 
     mongo_client = config["mongo_client"]
     mongo_operator = MongoOperator(client=mongo_client)
@@ -154,7 +158,7 @@ async def lmeh_evaluate(args: PocketNetworkEvaluationTaskRequest) -> bool:
                 try:
                     # it is loading data from sql to a dataset
                     await task_dict[task_name].load_from_sql()
-                    eval_logger.info("Task loaded successfully:", task_dict=task_dict)
+                    eval_logger.debug("Task loaded successfully:", task_dict=task_dict)
                 except ApplicationError as e:
                     raise e
                 except Exception as error:

--- a/apps/python/evaluator/activities/signatures/tokenizer_evaluate.py
+++ b/apps/python/evaluator/activities/signatures/tokenizer_evaluate.py
@@ -94,29 +94,29 @@ async def tokenizer_evaluate(args: PocketNetworkEvaluationTaskRequest) -> bool:
             tokenizer_ok = True
         except Exception as e:
             # This is not an error is just a failure in retrieval of tokenizer
-            eval_logger.info(f"Cannot load tokenizer from response.")
-            eval_logger.debug(f"Exeption:", Exeption=str(e))
+            eval_logger.info("Cannot load tokenizer from response.")
+            eval_logger.debug("Exeption:", Exeption=str(e))
             tokenizer_ok = False
 
     tokenizer_new = False
     if tokenizer_ok:
         # check if the tokenizer exists in db
         tokenizer_db = await mongo_operator.get_tokenizer_entry(tokenizer_mongo_new.hash)
-        if tokenizer_db == None:
+        if tokenizer_db is None:
             eval_logger.debug("Tokenizer does not exists.")
             # the tokenizer is not tracked, we need to create an entry
             tokenizer_new = True
             try:
                 async with mongo_client.start_transaction() as session:
                     await mongo_client.db["tokenizers"].insert_many(
-                        [tokenizer_mongo_new],
+                        [tokenizer_mongo_new.model_dump(by_alias=True)],
                         ordered=False,
                         session=session,
                     )
                 eval_logger.debug("Saved new tokenizer to DB.")
             except Exception as e:
                 eval_logger.error("Failed to save Tokenizer to MongoDB.")
-                eval_logger.error(f"Exeption:", Exeption=str(e))
+                eval_logger.error("Exeption:", Exeption=str(e))
                 raise ApplicationError("Failed to save tokenizer to MongoDB.", non_retryable=True)
 
         # Update the result with valid data

--- a/apps/python/sampler/activities/lmeh/sample.py
+++ b/apps/python/sampler/activities/lmeh/sample.py
@@ -5,6 +5,7 @@ from packages.python.lmeh.utils.common import get_task_manager
 from app.app import get_app_logger, get_app_config
 from packages.python.protocol.protocol import PocketNetworkTaskRequest
 from packages.python.lmeh.utils import generator as lmeh_generator
+from packages.python.lmeh.utils import task_config as open_llm_config
 from packages.python.lmeh.pocket_lm_eval.models.pocket_network import PocketNetworkLM
 from activities.utils import auto_heartbeater
 from packages.python.lmeh.utils import sql as lmeh_sql
@@ -57,6 +58,8 @@ async def lmeh_sample(args: PocketNetworkTaskRequest) -> bool:
 
                 # generate configurable tasks
                 try:
+                    open_llm_cfg = open_llm_config.get_task_config(task_names[0])
+                    args.num_fewshot = open_llm_cfg["num_fewshot"]                    
                     task_dict = lmeh_generator.get_configurable_task(
                         tasks=[task_name],
                         num_fewshot=args.num_fewshot,

--- a/docker-compose/morse-poc/apps_configs/evaluator.json
+++ b/docker-compose/morse-poc/apps_configs/evaluator.json
@@ -1,7 +1,7 @@
 {
     "postgres_uri": "postgresql://admin:admin@postgresql:5432/pocket-ml-testbench",
     "mongodb_uri": "mongodb://mongodb:27017/pocket-ml-testbench",
-    "log_level": "DEBUG",
+    "log_level": "INFO",
     "temporal": {
       "host": "temporal",
       "port": 7233,

--- a/docker-compose/morse-poc/dependencies_configs/mongodb/init-db.js
+++ b/docker-compose/morse-poc/dependencies_configs/mongodb/init-db.js
@@ -1,7 +1,7 @@
 db = db.getSiblingDB('pocket-ml-testbench');
 
 db.createCollection('tokenizers');
-db.tokenizers.createIndex({hash: 1});
+db.tokenizers.createIndex({hash: 1}, {unique: true});
 
 db.createCollection('tasks');
 db.tasks.createIndex({

--- a/packages/python/lmeh/pocket_lm_eval/api/task.py
+++ b/packages/python/lmeh/pocket_lm_eval/api/task.py
@@ -378,7 +378,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
             # validate that the split exists in the _split_ranges
             self.check_split_exist(_split, _split_ranges)
         else:
-            self.eval_logger.error(f"Config without splits:", config=self.config)
+            self.eval_logger.error("Config without splits:", config=self.config)
             raise ApplicationError(
                 f"Neither {self.config.test_split} nor {self.config.validation_split} in splits were found in "
                 f"'_split_ranges'. Available splits are {_split_ranges.keys()}",
@@ -393,7 +393,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
             if doc_ids:
                 if _split != self.get_split_from_ids(_split_ranges, doc_ids):
                     self.eval_logger.error(
-                        f"Doc_ids not in split range used for evaluation:",
+                        "Doc_ids not in split range used for evaluation:",
                         doc_ids=doc_ids,
                         _split=_split,
                         range_min=_range['min'],
@@ -420,13 +420,14 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         # assign dataset as dataset dictionary
         ds_dict = DatasetDict()
         for split in ds.unique("__split"):
-            self.eval_logger.debug(f"Adding split to DatasetDict:", split=split)
+            self.eval_logger.debug("Adding split to DatasetDict:", split=split)
             ds_dict[split] = ds.filter(lambda x: x["__split"] == split)
-        self.dataset = ds_dict.remove_columns(["__id", "__split"])
+        self.dataset = ds_dict.remove_columns(["__split"])
         # save in config the indexes used to download the dataset
         self._config.metadata['pocket_args'].doc_ids = indexes
         # Update qty to the number of documents downloaded
         self._config.metadata['pocket_args'].qty = len(indexes)
+        self.eval_split = _split
         ###########################################################
         # call the code that was after the download on the __init__
         ###########################################################
@@ -616,7 +617,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         This function checks if a self.config.split exists in the keys of _split_ranges
         """
         if split not in _split_ranges.keys():
-            self.eval_logger.error(f"Split not found in _split_ranges:", split=split, _split_ranges=_split_ranges)
+            self.eval_logger.error("Split not found in _split_ranges:", split=split, _split_ranges=_split_ranges)
             raise ApplicationError(
                 f"'{split}' split not found in _split_ranges: {_split_ranges.keys()}",
                 non_retryable=True
@@ -636,7 +637,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         """
         min_range = _split_ranges[split]['min']
         max_range = _split_ranges[split]['max'] + 1
-        self.eval_logger.debug(f"Adding ids from split range:", split=split, min_range=min_range, max_range=max_range)
+        self.eval_logger.debug("Adding ids from split range:", split=split, min_range=min_range, max_range=max_range)
         id_list_str += ', '.join(str(id) for id in range(min_range, max_range))
         return id_list_str
 
@@ -647,7 +648,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         """
         # check that the quantity of numbers to generate is less than the range
         if qty > (max - min + 1):
-            self.eval_logger.error(f"quantity overflow:", table_name=table_name, _split=_split, qty=qty, range_min=min,
+            self.eval_logger.error("quantity overflow:", table_name=table_name, _split=_split, qty=qty, range_min=min,
                                    range_max=max)
             raise ApplicationError(
                 "Quantity of numbers to generate is greater than the range",
@@ -661,7 +662,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
             ints = ints - set(blacklist)
             # Check that the blacklist numbers were removed
             if len(ints) == original_len:
-                self.eval_logger.error(f"Blacklist out of range:", table_name=table_name, _split=_split, range_min=min,
+                self.eval_logger.error("Blacklist out of range:", table_name=table_name, _split=_split, range_min=min,
                                        range_max=max, blacklist=blacklist)
                 raise ApplicationError(
                     "Blacklist corresponding to '{}' table & '{}' split were not founded in the range: [{}-{}]".format(
@@ -670,7 +671,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
                 )
         # sorted random numbers
         choices = sorted(np.random.choice(list(ints), qty, replace=False).tolist())
-        self.eval_logger.debug(f"Random numbers generated:", choices=choices)
+        self.eval_logger.debug("Random numbers generated:", choices=choices)
         return choices
 
     def get_all_doc_ids(self, _split: str, _split_ranges: dict) -> List[int]:
@@ -679,7 +680,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         """
         min_range = _split_ranges[_split]['min']
         max_range = _split_ranges[_split]['max'] + 1
-        self.eval_logger.debug(f"Getting all ids from split range:", split=_split, min_range=min_range,
+        self.eval_logger.debug("Getting all ids from split range:", split=_split, min_range=min_range,
                                max_range=max_range)
         return list(range(min_range, max_range))
 
@@ -693,7 +694,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         if self.config.test_split:
             self.check_split_exist(self.config.test_split, _split_ranges)
             if _split != self.config.test_split:
-                self.eval_logger.error(f"mismatch test_split:", _split=_split, test_split=self.config.test_split)
+                self.eval_logger.error("mismatch test_split:", _split=_split, test_split=self.config.test_split)
                 raise ApplicationError(
                     f"_split '{_split}' not equal to test_split '{self.config.test_split}'",
                     non_retryable=True
@@ -716,7 +717,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         elif self.config.validation_split:
             self.check_split_exist(self.config.validation_split, _split_ranges)
             if _split != self.config.validation_split:
-                self.eval_logger.error(f"mismatch validation_split:", _split=_split,
+                self.eval_logger.error("mismatch validation_split:", _split=_split,
                                        validation_split=self.config.validation_split)
                 raise ApplicationError(
                     f"_split '{_split}' not equal to validation_split '{self.config.validation_split}'",
@@ -731,7 +732,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
                 self.check_split_exist(self.config.fewshot_split, _split_ranges)
                 id_list_str = self.add_string_ids_range(self.config.fewshot_split, id_list_str, _split_ranges)
         else:
-            self.eval_logger.error(f"Config without splits:", config=self.config)
+            self.eval_logger.error("Config without splits:", config=self.config)
             raise ApplicationError(
                 "Neither test_split nor validation_split in config, cannot proceed, please check get_SQL_where_clause",
                 non_retryable=True
@@ -776,7 +777,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
                 GROUP BY
                     "__split";
             """.format(table_name)
-            self.eval_logger.debug(f"SQL query:", sql_query=sql_query)
+            self.eval_logger.debug("SQL query:", sql_query=sql_query)
 
             # Fetch all rows from the result
             rows = await postgres_conn.fetch(sql_query)
@@ -789,7 +790,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
             for row in rows:
                 _split_ranges[row[0]] = {'min': row[1], 'max': row[2]}
         except Exception as error:
-            self.eval_logger.error(f"Error while connecting to PostgreSQL:", error=error)
+            self.eval_logger.error("Error while connecting to PostgreSQL:", error=error)
             raise ApplicationError("Error while connecting to PostgreSQL", non_retryable=True)
 
         return _split_ranges
@@ -828,22 +829,18 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
                     break
         # all ids should belong to a split range
         if len(split_range) != len(__ids):
-            self.eval_logger.error(f"Ids not in split range:", split_range=split_range, __ids=__ids)
+            self.eval_logger.error("Ids not in split range:", split_range=split_range, __ids=__ids)
             raise ApplicationError("Some ids do not belong to any split range", non_retryable=True)
 
         # all ids should belong to a unique split range
         if len(set(split_range)) != 1:
-            self.eval_logger.error(f"Ids in more than one split:", __ids=__ids, split_range=split_range)
+            self.eval_logger.error("Ids in more than one split:", __ids=__ids, split_range=split_range)
             raise ApplicationError("Some ids belong to more than one split.", non_retryable=True)
 
         return list(set(split_range))[0]
 
 
 class EvaluatePocketNetworkConfigurableTask(PocketNetworkConfigurableTask):
-    # todo: override __init__ and receive also mongo_client to set on self.mongo_client avoiding pass it on build_all_requests
-    # like we are already doing on PocketNetworkConfigurableTask
-    # after do that remember call super().__init__(*args, **kwargs)
-    # noinspection PyMethodOverriding
     async def build_all_requests(
             self,
             *,
@@ -857,12 +854,13 @@ class EvaluatePocketNetworkConfigurableTask(PocketNetworkConfigurableTask):
             rewrite_requests_cache=False,
     ) -> None:
         """Build a set of Instances for a task, and store them in task.instances"""
-        self._instances = await MongoOperator(client=mongo_client).reconstruct_instances(task_id=task_id)
-
-        if len(self._instances) == 0:
-            raise ApplicationError(
-                "task.build_all_requests() did not find any docs!",
-                task_id,
-                type="DocumentsNotFound",
-                non_retryable=False,
-            )
+        self._instances, kept_doc_ids = await MongoOperator(client=mongo_client).reconstruct_instances(task_id=task_id, eval_logger=self.eval_logger)
+        # Kept only those docs_ids filled by all its instances/responses
+        if kept_doc_ids:
+            b_dict = {}
+            for i, b in enumerate(self.config.metadata['pocket_args'].doc_ids):
+                b_dict[b] = i
+            a_indices = [b_dict[a] for a in kept_doc_ids]
+            self.dataset[self.eval_split] = Dataset.from_dict(self.dataset[self.eval_split][a_indices])
+            for doc_id in self.eval_docs:
+                self.eval_logger.info("Doc_id:", doc_id=doc_id)

--- a/packages/python/lmeh/pocket_lm_eval/api/task.py
+++ b/packages/python/lmeh/pocket_lm_eval/api/task.py
@@ -854,7 +854,7 @@ class EvaluatePocketNetworkConfigurableTask(PocketNetworkConfigurableTask):
             rewrite_requests_cache=False,
     ) -> None:
         """Build a set of Instances for a task, and store them in task.instances"""
-        self._instances, kept_doc_ids = await MongoOperator(client=mongo_client).reconstruct_instances(task_id=task_id, eval_logger=self.eval_logger)
+        self._instances, kept_doc_ids, self.result_height = await MongoOperator(client=mongo_client).reconstruct_instances(task_id=task_id, eval_logger=self.eval_logger)
         # Kept only those docs_ids filled by all its instances/responses
         if kept_doc_ids:
             b_dict = {}
@@ -862,5 +862,3 @@ class EvaluatePocketNetworkConfigurableTask(PocketNetworkConfigurableTask):
                 b_dict[b] = i
             a_indices = [b_dict[a] for a in kept_doc_ids]
             self.dataset[self.eval_split] = Dataset.from_dict(self.dataset[self.eval_split][a_indices])
-            for doc_id in self.eval_docs:
-                self.eval_logger.info("Doc_id:", doc_id=doc_id)

--- a/packages/python/lmeh/pocket_lm_eval/tasks/__init__.py
+++ b/packages/python/lmeh/pocket_lm_eval/tasks/__init__.py
@@ -71,9 +71,9 @@ class PocketNetworkTaskManager(TaskManager):
             else:
                 config = self._process_alias(config, group=group)
                 if self.stage == TASK_MANAGER_REGISTER_STAGE or self.stage == TASK_MANAGER_SAMPLE_STAGE:
-                    task_object = PocketNetworkConfigurableTask(config=config, postgres_conn=self.postgres_conn)
+                    task_object = PocketNetworkConfigurableTask(config=config, postgres_conn=self.postgres_conn, eval_logger=self.logger)
                 elif self.stage == TASK_MANAGER_EVALUATE_STAGE:
-                    task_object = EvaluatePocketNetworkConfigurableTask(config=config, postgres_conn=self.postgres_conn)
+                    task_object = EvaluatePocketNetworkConfigurableTask(config=config, postgres_conn=self.postgres_conn, eval_logger=self.logger)
                 else:
                     ApplicationError(f"Stage {self.stage} not supported", non_retryable=True)
             if group is not None:

--- a/packages/python/lmeh/utils/common.py
+++ b/packages/python/lmeh/utils/common.py
@@ -33,6 +33,7 @@ def get_task_manager(
         include_path=include_path,
         pocket_args=pocket_args,
         stage=stage,
+        logger=logger,
     )
 
     if tasks is None:

--- a/packages/python/lmeh/utils/task_config.py
+++ b/packages/python/lmeh/utils/task_config.py
@@ -8,11 +8,11 @@ task_cnfg = {
         "num_fewshot":10
         },
     "truthfulqa_mc2": {
-        "metric": "mc2",
+        "metric": "acc",
         "num_fewshot":0
         },
     "mmlu": {
-        "metric": "average",
+        "metric": "acc",
         "num_fewshot":5
         },
     "winogrande": {

--- a/packages/python/lmeh/utils/tokenizers.py
+++ b/packages/python/lmeh/utils/tokenizers.py
@@ -19,7 +19,7 @@ def _get_tokenizer_jsons(tokenizer: Union[PreTrainedTokenizer, PreTrainedTokeniz
     """Get tokenizer jsons been used"""
     CURRENT_DIR = os.path.dirname(__file__)
     
-    if TOKENIZER_EPHIMERAL_PATH == None:
+    if TOKENIZER_EPHIMERAL_PATH is None:
         TOKENIZER_EPHIMERAL_PATH = Path(
             os.path.join(CURRENT_DIR, "tmp_tokenizer"))
     else:

--- a/packages/python/protocol/protocol.py
+++ b/packages/python/protocol/protocol.py
@@ -1,5 +1,6 @@
 import time
 import uuid
+from datetime import datetime
 from typing import List, Literal, Optional, Union, Dict
 from bson import ObjectId
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -228,6 +229,9 @@ class PocketNetworkMongoDBResultBase(BaseModel):
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     task_id: ObjectId
     num_samples: int
+    status: int
+    result_height: int
+    result_time: datetime
 
     class Config:
         arbitrary_types_allowed = True

--- a/packages/python/protocol/protocol.py
+++ b/packages/python/protocol/protocol.py
@@ -259,3 +259,4 @@ class PocketNetworkMongoDBTokenizer(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+    scores: List[NumericSample]

--- a/packages/python/protocol/protocol.py
+++ b/packages/python/protocol/protocol.py
@@ -227,7 +227,7 @@ class CompletionResponse(OpenAIBaseModel):
 class PocketNetworkMongoDBResultBase(BaseModel):
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     task_id: ObjectId
-    num_samples:    int
+    num_samples: int
 
     class Config:
         arbitrary_types_allowed = True
@@ -259,4 +259,3 @@ class PocketNetworkMongoDBTokenizer(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-    scores: List[NumericSample]


### PR DESCRIPTION
This PR concludes the Evaluator (hopefully). The main changes can be summarized as:

1. Responses not properly formated or not answered at all are removed.
2. Only those `docs_ids` filled by all its `instances`/`responses` are kept. This implies also filtering those `docs_ids` from self.dataset[self.eval_split].
3. `get_task_manager` now initialize properly the logger into `EvaluatePocketNetworkConfigurableTask`.
4. In MongoDB , the `'tokenizer'` index now include `inique=true`.
5. Fix metrics in `packages/python/lmeh/utils/task_config.py`.
6. Code to save result in mongoDB in `PocketNetworkMongoDBResultNumerical` format.