### PR TITLE
69 go tests  circular buffers

### DIFF
--- a/apps/go/manager/activities/analyze_node.go
+++ b/apps/go/manager/activities/analyze_node.go
@@ -120,7 +120,7 @@ func (aCtx *Ctx) AnalyzeNode(ctx context.Context, params types.AnalyzeNodeParams
 				}
 
 				// Get number of tasks in queue
-				inQueue, _, blackList, _, err := CheckTaskDatabase(thisNodeData.Address, thisNodeData.Service, test.Framework, task, aCtx.App.Mongodb, l)
+				inQueue, _, blackList, _, err := checkTaskDatabase(thisNodeData.Address, thisNodeData.Service, test.Framework, task, aCtx.App.Mongodb, l)
 				if err != nil {
 					return nil, err
 				}
@@ -203,7 +203,7 @@ func updateTasksNode(nodeData *records.NodeRecord, tests []types.TestsData, fram
 			//------------------------------------------------------------------
 			// Check pending and done tasks in the database
 			//------------------------------------------------------------------
-			_, tasksDone, _, tasksIDs, err := CheckTaskDatabase(nodeData.Address, nodeData.Service, test.Framework, task, mongoDB, l)
+			_, tasksDone, _, tasksIDs, err := checkTaskDatabase(nodeData.Address, nodeData.Service, test.Framework, task, mongoDB, l)
 			if err != nil {
 				l.Debug().Str("address", nodeData.Address).Str("service", nodeData.Service).Str("framework", test.Framework).Str("task", task).Msg("Cannot check Tasks Database.")
 				return err
@@ -275,7 +275,7 @@ func updateTasksNode(nodeData *records.NodeRecord, tests []types.TestsData, fram
 }
 
 // Looks for a framework-task-node in the TaskDB and retreives all the IDs adn tasks status
-func CheckTaskDatabase(address string, service string, framework string, task string, mongoDB mongodb.MongoDb, l *zerolog.Logger) (tasksInQueue uint32, tasksDone uint32, blackList []int, tasksIDs []primitive.ObjectID, err error) {
+func checkTaskDatabase(address string, service string, framework string, task string, mongoDB mongodb.MongoDb, l *zerolog.Logger) (tasksInQueue uint32, tasksDone uint32, blackList []int, tasksIDs []primitive.ObjectID, err error) {
 	// define blacklist as length zero
 	blackList = make([]int, 0)
 

--- a/apps/go/manager/activities/entry.go
+++ b/apps/go/manager/activities/entry.go
@@ -17,10 +17,15 @@ type Ctx struct {
 var Activities *Ctx
 
 // SetAppConfig sets the provided app configuration to the global Activities variable in the Ctx struct.
-func SetAppConfig(ac *types.App) {
-	Activities = &Ctx{
-		App: ac,
+func SetAppConfig(ac *types.App) *Ctx {
+	if Activities != nil {
+		Activities.App = ac
+	} else {
+		Activities = &Ctx{
+			App: ac,
+		}
 	}
+	return Activities
 }
 
 // Register registers a worker activity with the provided activity function in the Ctx struct.

--- a/apps/go/manager/activities/get_staked.go
+++ b/apps/go/manager/activities/get_staked.go
@@ -57,15 +57,15 @@ func (aCtx *Ctx) GetStaked(ctx context.Context, params types.GetStakedParams) (*
 		l.Error().Str("service", params.Service).Msg("Cannot get blocks per session parameter.")
 		return nil, err
 	}
-
-	result.Block.Height = currHeight
 	i64, err := strconv.ParseInt(blocksPerSession, 10, 64)
 	if err != nil {
 		l.Error().Str("service", params.Service).Msg("Could convert parameter to number.")
 		return nil, err
 	}
 
+	// Assign
 	result.Block.BlocksPerSession = i64
+	result.Block.Height = currHeight
 
 	return &result, nil
 }

--- a/apps/go/manager/tests/circular_buffer_test.go
+++ b/apps/go/manager/tests/circular_buffer_test.go
@@ -14,7 +14,7 @@ type CircularBuffertUnitTestSuite struct {
 // Size of the buffer to test
 const testBufferLen uint32 = 50
 
-func (s *CircularBuffertUnitTestSuite) Test_GetHeight_Activity() {
+func (s *CircularBuffertUnitTestSuite) Test_CircularBuffer() {
 
 	// Create a test circular buffer
 	timeArray := make([]time.Time, testBufferLen)
@@ -203,13 +203,5 @@ func (s *CircularBuffertUnitTestSuite) Test_GetHeight_Activity() {
 	if uint32(len(validIdx)) != testCircularBuffer.NumSamples {
 		s.T().Error(fmt.Errorf("Number of valid elements in the buffer is not equal to the number of samples counted (index cycling):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, uint32(len(validIdx)), testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
 	}
-
-	// // Generate a random value [-1,1]
-	// randHere := ((rand.Float64() * 2) - 1) * math.Pi
-
-	// Save sample
-	// dataVector[testCircularBuffer.Indexes.End] = math.Sin(randHere)
-
-	// fill the buffer following a simple sinusoidal function
 
 }

--- a/apps/go/manager/tests/circular_buffer_test.go
+++ b/apps/go/manager/tests/circular_buffer_test.go
@@ -41,7 +41,6 @@ func (s *CircularBuffertUnitTestSuite) Test_CircularBuffer() {
 	// Check step function
 	stepsMove := int(testBufferLen / 2)
 	for step := 0; step < stepsMove; step++ {
-
 		// Increment the end
 		err := testCircularBuffer.StepIndex(1, "end", true, s.app.Logger)
 		if err != nil {
@@ -50,7 +49,6 @@ func (s *CircularBuffertUnitTestSuite) Test_CircularBuffer() {
 		}
 		// Add time
 		testCircularBuffer.Times[testCircularBuffer.Indexes.End] = time.Now()
-
 	}
 	if uint32(stepsMove) != testCircularBuffer.NumSamples {
 		s.T().Error(fmt.Errorf("Number of elements in the buffer is not equal to the number of steps taken:  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, stepsMove, testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
@@ -67,7 +65,6 @@ func (s *CircularBuffertUnitTestSuite) Test_CircularBuffer() {
 	// Make an overflow
 	stepsMove = int(testBufferLen)
 	for step := 0; step < stepsMove; step++ {
-
 		// Increment the end
 		err := testCircularBuffer.StepIndex(1, "end", true, s.app.Logger)
 		if err != nil {
@@ -100,7 +97,6 @@ func (s *CircularBuffertUnitTestSuite) Test_CircularBuffer() {
 			s.T().Error(err)
 			return
 		}
-		// fmt.Print(testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End, testCircularBuffer.NumSamples, "\n")
 	}
 	if 0 != testCircularBuffer.NumSamples {
 		s.T().Error(fmt.Errorf("Number of elements in the buffer is not equal to the number of steps taken (moving end backwards):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, 0, testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
@@ -118,7 +114,6 @@ func (s *CircularBuffertUnitTestSuite) Test_CircularBuffer() {
 	// move end 5 and then start 10
 	stepsMove = int(5)
 	for step := 0; step < stepsMove; step++ {
-
 		// Increment the end
 		err := testCircularBuffer.StepIndex(1, "end", true, s.app.Logger)
 		if err != nil {
@@ -142,7 +137,6 @@ func (s *CircularBuffertUnitTestSuite) Test_CircularBuffer() {
 	}
 	stepsMove = int(10)
 	for step := 0; step < stepsMove; step++ {
-
 		// Increment the end
 		err := testCircularBuffer.StepIndex(1, "start", true, s.app.Logger)
 		if err != nil {
@@ -150,7 +144,6 @@ func (s *CircularBuffertUnitTestSuite) Test_CircularBuffer() {
 			return
 		}
 
-		// fmt.Print(testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End, testCircularBuffer.NumSamples, "\n")
 	}
 	if 0 != testCircularBuffer.NumSamples {
 		s.T().Error(fmt.Errorf("Number of elements in the buffer is not equal to the number of steps taken (moving start forward):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, 0, testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
@@ -168,10 +161,8 @@ func (s *CircularBuffertUnitTestSuite) Test_CircularBuffer() {
 	// Check  cycling
 
 	// move end 4
-	// fmt.Print(testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End, "\n")
 	stepsMove = int(4)
 	for step := 0; step < stepsMove; step++ {
-
 		// Increment the end
 		err := testCircularBuffer.StepIndex(1, "end", true, s.app.Logger)
 		if err != nil {

--- a/apps/go/manager/tests/circular_buffer_test.go
+++ b/apps/go/manager/tests/circular_buffer_test.go
@@ -1,0 +1,215 @@
+package tests
+
+import (
+	"fmt"
+	"manager/types"
+	"time"
+)
+
+// define a test suite struct
+type CircularBuffertUnitTestSuite struct {
+	BaseSuite
+}
+
+// Size of the buffer to test
+const testBufferLen uint32 = 50
+
+func (s *CircularBuffertUnitTestSuite) Test_GetHeight_Activity() {
+
+	// Create a test circular buffer
+	timeArray := make([]time.Time, testBufferLen)
+	for i := range timeArray {
+		timeArray[i] = types.EpochStart.UTC()
+	}
+	testCircularBuffer := types.CircularBuffer{
+		CircBufferLen: testBufferLen,
+		NumSamples:    0,
+		Times:         timeArray,
+		Indexes: types.CircularIndexes{
+			Start: 0,
+			End:   0,
+		},
+	}
+
+	// // Create the data vector that will be governed by the buffer
+	// dataVector := make([]float64, testBufferLen)
+
+	// // Create a vector larger than the buffer length to keep as ground truth
+	// truthVector := make([]float64, testBufferLen*2)
+
+	// ---- Test buffer with unitary steps
+	// Check step function
+	stepsMove := int(testBufferLen / 2)
+	for step := 0; step < stepsMove; step++ {
+
+		// Increment the end
+		err := testCircularBuffer.StepIndex(1, "end", true, s.app.Logger)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+		// Add time
+		testCircularBuffer.Times[testCircularBuffer.Indexes.End] = time.Now()
+
+	}
+	if uint32(stepsMove) != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of elements in the buffer is not equal to the number of steps taken:  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, stepsMove, testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+	// Check number of valid samples
+	validIdx, err := testCircularBuffer.GetBufferValidIndexes(s.app.Logger)
+	if err != nil {
+		s.T().Error(err)
+		return
+	}
+	if uint32(len(validIdx)) != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of valid elements in the buffer is not equal to the number of samples counted:  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, uint32(len(validIdx)), testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+	// Make an overflow
+	stepsMove = int(testBufferLen)
+	for step := 0; step < stepsMove; step++ {
+
+		// Increment the end
+		err := testCircularBuffer.StepIndex(1, "end", true, s.app.Logger)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+		// Add time
+		testCircularBuffer.Times[testCircularBuffer.Indexes.End] = time.Now()
+	}
+	if uint32(testBufferLen) != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of elements in the buffer not equal to the buffer length after an overflow:  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, stepsMove, testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+	// Check number of valid samples
+	validIdx, err = testCircularBuffer.GetBufferValidIndexes(s.app.Logger)
+	if err != nil {
+		s.T().Error(err)
+		return
+	}
+	if uint32(len(validIdx)) != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of valid elements in the buffer is not equal to the number of samples counted (after overflow):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, uint32(len(validIdx)), testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+
+	// Go back all samples
+	stepsMove = int(testBufferLen)
+	for step := 0; step < stepsMove; step++ {
+
+		// Increment the end
+		err := testCircularBuffer.StepIndex(1, "end", false, s.app.Logger)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+		// fmt.Print(testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End, testCircularBuffer.NumSamples, "\n")
+	}
+	if 0 != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of elements in the buffer is not equal to the number of steps taken (moving end backwards):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, 0, testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+	// Check number of valid samples
+	validIdx, err = testCircularBuffer.GetBufferValidIndexes(s.app.Logger)
+	if err != nil {
+		s.T().Error(err)
+		return
+	}
+	if uint32(len(validIdx)) != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of valid elements in the buffer is not equal to the number of samples counted (moving end backwards):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, uint32(len(validIdx)), testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+
+	// move end 5 and then start 10
+	stepsMove = int(5)
+	for step := 0; step < stepsMove; step++ {
+
+		// Increment the end
+		err := testCircularBuffer.StepIndex(1, "end", true, s.app.Logger)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+		// Add time
+		testCircularBuffer.Times[testCircularBuffer.Indexes.End] = time.Now()
+	}
+	if 5 != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of elements in the buffer is not equal to the number of steps taken (moving end forward):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, 5, testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+	// Check number of valid samples
+	validIdx, err = testCircularBuffer.GetBufferValidIndexes(s.app.Logger)
+	if err != nil {
+		s.T().Error(err)
+		return
+	}
+	if uint32(len(validIdx)) != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of valid elements in the buffer is not equal to the number of samples counted (moving end forward):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, uint32(len(validIdx)), testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+	stepsMove = int(10)
+	for step := 0; step < stepsMove; step++ {
+
+		// Increment the end
+		err := testCircularBuffer.StepIndex(1, "start", true, s.app.Logger)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+
+		// fmt.Print(testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End, testCircularBuffer.NumSamples, "\n")
+	}
+	if 0 != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of elements in the buffer is not equal to the number of steps taken (moving start forward):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, 0, testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+	// Check number of valid samples
+	validIdx, err = testCircularBuffer.GetBufferValidIndexes(s.app.Logger)
+	if err != nil {
+		s.T().Error(err)
+		return
+	}
+	if uint32(len(validIdx)) != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of valid elements in the buffer is not equal to the number of samples counted (moving start forward):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, uint32(len(validIdx)), testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+
+	// Check  cycling
+
+	// move end 4
+	// fmt.Print(testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End, "\n")
+	stepsMove = int(4)
+	for step := 0; step < stepsMove; step++ {
+
+		// Increment the end
+		err := testCircularBuffer.StepIndex(1, "end", true, s.app.Logger)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+		// Add time
+		testCircularBuffer.Times[testCircularBuffer.Indexes.End] = time.Now()
+	}
+	// Change date of start sample to an old one
+	validIdx, err = testCircularBuffer.GetBufferValidIndexes(s.app.Logger)
+	testCircularBuffer.Times[validIdx[0]] = types.EpochStart
+	// Cycle indexes
+	err = testCircularBuffer.CycleIndexes(5, s.app.Logger)
+	if err != nil {
+		s.T().Error(err)
+		return
+	}
+	// Valid samples must be 4
+	if uint32(stepsMove-1) != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Index cycling not dropping old sample:  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, stepsMove-1, testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+	// Check number of valid samples
+	validIdx, err = testCircularBuffer.GetBufferValidIndexes(s.app.Logger)
+	if err != nil {
+		s.T().Error(err)
+		return
+	}
+	if uint32(len(validIdx)) != testCircularBuffer.NumSamples {
+		s.T().Error(fmt.Errorf("Number of valid elements in the buffer is not equal to the number of samples counted (index cycling):  got = %v, want %v (Start Idx: %v - End Idx : %v)", testCircularBuffer.NumSamples, uint32(len(validIdx)), testCircularBuffer.Indexes.Start, testCircularBuffer.Indexes.End))
+	}
+
+	// // Generate a random value [-1,1]
+	// randHere := ((rand.Float64() * 2) - 1) * math.Pi
+
+	// Save sample
+	// dataVector[testCircularBuffer.Indexes.End] = math.Sin(randHere)
+
+	// fill the buffer following a simple sinusoidal function
+
+}

--- a/apps/go/manager/tests/main_test.go
+++ b/apps/go/manager/tests/main_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"manager/activities"
+	"manager/types"
+	"manager/workflows"
+	"os"
+	"packages/logger"
+	"packages/mongodb"
+	"packages/pocket_rpc"
+	"packages/pocket_rpc/samples"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type BaseSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+
+	workflowEnv *testsuite.TestWorkflowEnvironment
+	activityEnv *testsuite.TestActivityEnvironment
+
+	app     *types.App
+	mockRpc *pocket_rpc.MockRpc
+}
+
+func (s *BaseSuite) InitializeTestApp() {
+	// initialize logger
+	l := zerolog.New(zerolog.ConsoleWriter{
+		Out:        os.Stderr,
+		TimeFormat: time.RFC3339,
+	}).Level(zerolog.NoLevel).With().Timestamp().Logger()
+
+	samples.SetBasePath(path.Join("..", "..", "..", "..", "packages", "go", "pocket_rpc", "samples"))
+
+	// mock App config
+	cfg := &types.Config{
+		MongodbUri: types.DefaultMongodbUri,
+		Rpc: &types.RPCConfig{
+			Urls:       []string{},
+			Retries:    0,
+			MinBackoff: 1,
+			MaxBackoff: 10,
+			ReqPerSec:  1,
+		},
+		LogLevel: types.DefaultLogLevel,
+		Temporal: &types.TemporalConfig{
+			Host:      types.DefaultTemporalHost,
+			Port:      types.DefaultTemporalPort,
+			Namespace: types.DefaultTemporalNamespace,
+			TaskQueue: types.DefaultTemporalTaskQueue,
+			Sampler: &types.SamplerConfig{
+				WorkflowName: "Sampler",
+				TaskQueue:    "sampler",
+			},
+		},
+	}
+
+	ac := &types.App{
+		Logger:         &l,
+		Config:         cfg,
+		PocketRpc:      pocket_rpc.NewMockRpc(),
+		Mongodb:        &mongodb.MockClient{},
+		TemporalClient: &TemporalClientMock{},
+	}
+
+	// set the app to test env
+	s.app = ac
+
+	return
+}
+
+func (s *BaseSuite) BeforeTest(_, _ string) {
+	s.InitializeTestApp()
+
+	zeroLoggerAdapter := logger.NewZerologAdapter(*s.app.Logger)
+	s.SetLogger(zeroLoggerAdapter)
+
+	s.app.Mongodb = mongodb.NewMockClient("mongodb://localhost:27017/test", s.app.Logger)
+
+	// set this to workflows and activities to avoid use of context.Context
+	wCtx := workflows.SetAppConfig(s.app)
+	aCtx := activities.SetAppConfig(s.app)
+
+	s.workflowEnv = s.NewTestWorkflowEnvironment()
+	s.activityEnv = s.NewTestActivityEnvironment()
+
+	var activityList = []interface{}{
+		aCtx.AnalyzeNode,
+		aCtx.GetStaked,
+		aCtx.TriggerSampler,
+	}
+
+	// register the activities that will need to be mock up here
+	for i := range activityList {
+		s.activityEnv.RegisterActivity(activityList[i])
+		s.workflowEnv.RegisterActivity(activityList[i])
+	}
+
+	// register the workflows
+	s.workflowEnv.RegisterWorkflow(wCtx.NodeManager)
+}
+
+func (s *BaseSuite) GetPocketRpcMock() *pocket_rpc.MockRpc {
+	if s.app == nil || s.app.PocketRpc == nil {
+		panic("app or pocket rpc client not initialized")
+	}
+	if c, ok := s.app.PocketRpc.(*pocket_rpc.MockRpc); ok {
+		return c
+	} else {
+		panic("pocket rpc client is not an instance of pocket_rpc.MockRpc")
+	}
+}
+
+func (s *BaseSuite) GetMongoClientMock() *mongodb.MockClient {
+	if s.app == nil || s.app.Mongodb == nil {
+		panic("app or mongo client not initialized")
+	}
+	if c, ok := s.app.Mongodb.(*mongodb.MockClient); ok {
+		return c
+	} else {
+		panic("mongodb client is not an instance of mongodb.MockClient")
+	}
+}
+
+func (s *BaseSuite) GetTemporalClientMock() *TemporalClientMock {
+	if s.app == nil || s.app.TemporalClient == nil {
+		panic("app or temporal client not initialized")
+	}
+	if c, ok := s.app.TemporalClient.(*TemporalClientMock); ok {
+		return c
+	} else {
+		panic("temporal client is not an instance of tests.TemporalClientMock")
+	}
+}
+
+func TestAll(t *testing.T) {
+	// Test functionality
+	suite.Run(t, new(CircularBuffertUnitTestSuite))
+	// test all activities
+	// TODO
+	// then test the workflow that will use all those activities
+	// TODO
+}

--- a/apps/go/manager/tests/main_test.go
+++ b/apps/go/manager/tests/main_test.go
@@ -142,8 +142,11 @@ func (s *BaseSuite) GetTemporalClientMock() *TemporalClientMock {
 func TestAll(t *testing.T) {
 	// Test functionality
 	suite.Run(t, new(CircularBuffertUnitTestSuite))
+	suite.Run(t, new(RecordstUnitTestSuite))
+
 	// test all activities
 	// TODO
+
 	// then test the workflow that will use all those activities
 	// TODO
 }

--- a/apps/go/manager/tests/mock_types.go
+++ b/apps/go/manager/tests/mock_types.go
@@ -1,0 +1,75 @@
+package tests
+
+import (
+	"context"
+	"packages/pocket_rpc/samples"
+	"packages/utils"
+	"strconv"
+
+	poktGoSdk "github.com/pokt-foundation/pocket-go/provider"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/client"
+)
+
+type MockRelayData struct {
+	Height           int64
+	BlockParams      *poktGoSdk.AllParams
+	Session          *poktGoSdk.Session
+	App              *poktGoSdk.App
+	Node             *poktGoSdk.Node
+	Service          string
+	SessionHeight    int64
+	BlocksPerSession int64
+	RelayResponse    *poktGoSdk.RelayOutput
+}
+
+
+type TemporalClientMock struct {
+	client.Client
+	mock.Mock
+}
+
+func (m *TemporalClientMock) ExecuteWorkflow(ctx context.Context, options client.StartWorkflowOptions, workflow interface{}, args ...interface{}) (client.WorkflowRun, error) {
+	argsOut := m.Called(ctx, options, workflow, args)
+	return argsOut.Get(0).(client.WorkflowRun), argsOut.Error(1)
+}
+
+type FakeWorkflowRun struct {
+	mock.Mock
+	client.WorkflowRun
+}
+
+func (w *FakeWorkflowRun) GetID() string {
+	return w.Called().String(0)
+}
+
+func (w *FakeWorkflowRun) GetRunID() string {
+	return w.Called().String(0)
+}
+
+func GetRelayMockData(l *zerolog.Logger) *MockRelayData {
+	height, _ := samples.GetHeightMock(l).Height.Int64()
+	blockParams := samples.GetAllParamsMock(l)
+	session := samples.GetSessionMock(l).Session
+	app := samples.GetAppMock(l)
+	node := utils.GetRandomFromSlice[poktGoSdk.Node](session.Nodes)
+	service := *utils.GetRandomFromSlice[string](app.Chains)
+	sessionHeight := int64(session.Header.SessionHeight)
+	blocksPerSessionRaw, _ := blockParams.NodeParams.Get("pos/BlocksPerSession")
+	blocksPerSession, _ := strconv.ParseInt(blocksPerSessionRaw, 10, 64)
+	relayResponse := samples.GetSuccessRelayOutput(l)
+
+	return &MockRelayData{
+		Height:           height,
+		BlockParams:      blockParams,
+		Session:          session,
+		App:              app,
+		Node:             node,
+		Service:          service,
+		SessionHeight:    sessionHeight,
+		BlocksPerSession: blocksPerSession,
+		RelayResponse:    relayResponse,
+	}
+
+}

--- a/apps/go/manager/tests/records_test.go
+++ b/apps/go/manager/tests/records_test.go
@@ -1,0 +1,155 @@
+package tests
+
+import (
+	"fmt"
+	"manager/records"
+	"manager/types"
+	"sort"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"golang.org/x/exp/rand"
+	"gonum.org/v1/gonum/stat"
+)
+
+// define a test suite struct
+type RecordstUnitTestSuite struct {
+	BaseSuite
+}
+
+func (s *RecordstUnitTestSuite) Test_NumericalTaskRecord() {
+
+	// Create record
+	var record records.NumericalTaskRecord
+	// Initialize
+	record.NewTask(primitive.NewObjectID(), "framework", "task", types.EpochStart.UTC(), s.app.Logger)
+
+	// Create a vector larger than the buffer length to keep as ground truth
+	truthVector := make([]float64, records.NumericalCircularBufferLength*2)
+	// Fill the vector with random values
+	for i := range truthVector {
+		truthVector[i] = float64(rand.Intn(1000)) / 10.0
+	}
+
+	// Insert some values and check process results
+	numInitialInserts := 8
+	for step := 0; step < numInitialInserts; step++ {
+
+		// Create score sample
+		var sample records.ScoresSample
+		sample.Score = truthVector[step]
+		sample.ID = step
+		// Insert
+		err := record.InsertSample(time.Now(), sample, s.app.Logger)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+		// Process record data
+		record.ProcessData(s.app.Logger)
+	}
+
+	// Get truth data
+	partVector := truthVector[:numInitialInserts]
+	meanScore := float32(stat.Mean(partVector, nil))
+	stdScore := float32(stat.StdDev(partVector, nil))
+	var medianScore float32
+	sort.Float64s(partVector)
+	if numInitialInserts%2 == 0 {
+		medianScore = float32((partVector[numInitialInserts/2-1] + partVector[numInitialInserts/2]) / 2)
+	} else {
+		medianScore = float32(partVector[numInitialInserts/2])
+	}
+	if meanScore != record.MeanScore {
+		s.T().Error(fmt.Errorf("MeanScore wrong (initial insert):  got = %v, want %v", record.MeanScore, meanScore))
+	}
+	if stdScore != record.StdScore {
+		s.T().Error(fmt.Errorf("StdScore wrong (initial insert):  got = %v, want %v", record.StdScore, stdScore))
+	}
+	if medianScore != record.MedianScore {
+		s.T().Error(fmt.Errorf("MedianScore wrong (initial insert):  got = %v, want %v", record.MedianScore, medianScore))
+	}
+
+	// Make an overflow
+	for step := 0; step < int(records.NumericalCircularBufferLength); step++ {
+
+		// Create score sample
+		var sample records.ScoresSample
+		sample.Score = truthVector[numInitialInserts+step]
+		sample.ID = step
+		// Insert
+		err := record.InsertSample(time.Now(), sample, s.app.Logger)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+	}
+	// Process record data
+	record.ProcessData(s.app.Logger)
+	// Get truth data
+	partVector = truthVector[numInitialInserts:(numInitialInserts + int(records.NumericalCircularBufferLength))]
+	meanScore = float32(stat.Mean(partVector, nil))
+	stdScore = float32(stat.StdDev(partVector, nil))
+	sort.Float64s(partVector)
+	if records.NumericalCircularBufferLength%2 == 0 {
+		medianScore = float32((partVector[records.NumericalCircularBufferLength/2-1] + partVector[records.NumericalCircularBufferLength/2]) / 2)
+	} else {
+		medianScore = float32(partVector[records.NumericalCircularBufferLength/2])
+	}
+	if meanScore != record.MeanScore {
+		s.T().Error(fmt.Errorf("MeanScore wrong (overflow insert):  got = %v, want %v", record.MeanScore, meanScore))
+	}
+	if stdScore != record.StdScore {
+		s.T().Error(fmt.Errorf("StdScore wrong (overflow insert):  got = %v, want %v", record.StdScore, stdScore))
+	}
+	if medianScore != record.MedianScore {
+		s.T().Error(fmt.Errorf("MedianScore wrong (overflow insert):  got = %v, want %v", record.MedianScore, medianScore))
+	}
+
+}
+
+func (s *RecordstUnitTestSuite) Test_SignatureTaskRecord() {
+
+	// Create record
+	var record records.SignatureTaskRecord
+	// Initialize
+	record.NewTask(primitive.NewObjectID(), "framework", "task", types.EpochStart.UTC(), s.app.Logger)
+
+	// Define the character set
+	chars := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	// Define the length of the random string
+	length := 10
+	// Create some signatures
+	signatures := []string{}
+	numSignaturesTest := 5
+	for step := 0; step < numSignaturesTest; step++ {
+		// Create the random string
+		randString := ""
+		for i := 0; i < length; i++ {
+			randIndex := rand.Intn(len(chars))
+			randString += string(chars[randIndex])
+		}
+		signatures = append(signatures, randString)
+	}
+
+	for sign := range signatures {
+
+		// Create score sample
+		var sample records.SignatureSample
+		sample.Signature = signatures[sign]
+		sample.ID = sign
+		// Insert
+		err := record.InsertSample(time.Now(), sample, s.app.Logger)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+		// Process record data
+		record.ProcessData(s.app.Logger)
+	}
+
+	if signatures[numSignaturesTest-1] != record.LastSignature {
+		s.T().Error(fmt.Errorf("Signature does not match (initial insert):  got = %v, want %v", record.LastSignature, signatures[numSignaturesTest-1]))
+	}
+
+}

--- a/apps/go/manager/tests/records_test.go
+++ b/apps/go/manager/tests/records_test.go
@@ -18,7 +18,6 @@ type RecordstUnitTestSuite struct {
 }
 
 func (s *RecordstUnitTestSuite) Test_NumericalTaskRecord() {
-
 	// Create record
 	var record records.NumericalTaskRecord
 	// Initialize
@@ -34,7 +33,6 @@ func (s *RecordstUnitTestSuite) Test_NumericalTaskRecord() {
 	// Insert some values and check process results
 	numInitialInserts := 8
 	for step := 0; step < numInitialInserts; step++ {
-
 		// Create score sample
 		var sample records.ScoresSample
 		sample.Score = truthVector[step]
@@ -72,7 +70,6 @@ func (s *RecordstUnitTestSuite) Test_NumericalTaskRecord() {
 
 	// Make an overflow
 	for step := 0; step < int(records.NumericalCircularBufferLength); step++ {
-
 		// Create score sample
 		var sample records.ScoresSample
 		sample.Score = truthVector[numInitialInserts+step]
@@ -109,7 +106,6 @@ func (s *RecordstUnitTestSuite) Test_NumericalTaskRecord() {
 }
 
 func (s *RecordstUnitTestSuite) Test_SignatureTaskRecord() {
-
 	// Create record
 	var record records.SignatureTaskRecord
 	// Initialize
@@ -133,7 +129,6 @@ func (s *RecordstUnitTestSuite) Test_SignatureTaskRecord() {
 	}
 
 	for sign := range signatures {
-
 		// Create score sample
 		var sample records.SignatureSample
 		sample.Signature = signatures[sign]

--- a/apps/go/manager/types/circular_buffer.go
+++ b/apps/go/manager/types/circular_buffer.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"time"
 
@@ -27,7 +28,30 @@ type CircularBuffer struct {
 // Gets the sample index given a step direction (positive: 1 or negative: -1) and for a given marker (start or end of buffer)
 func (buffer *CircularBuffer) StepIndex(step uint32, marker string, positive_step bool, l *zerolog.Logger) error {
 
-	l.Debug().Int("buffer.Indexes.End", int(buffer.Indexes.Start)).Int("buffer.Indexes.End", int(buffer.Indexes.End)).Msg("Circular indexes.")
+	l.Debug().Int("buffer.Indexes.Start", int(buffer.Indexes.Start)).Int("buffer.Indexes.End", int(buffer.Indexes.End)).Int("step", int(step)).Msg("Circular indexes moving.")
+
+	if step > 1 {
+		return fmt.Errorf("Steps of length larger than 1 are not supported.")
+	}
+
+	// Check step feasibility
+	if marker == "start" {
+		if !positive_step {
+			// Cannot go back in time
+			l.Debug().Msg("Cannot move start index back.")
+			return nil
+		} else if buffer.NumSamples == 0 && positive_step {
+			// Cannot move this index
+			l.Debug().Msg("Cannot step over end index.")
+			return nil
+		}
+	} else {
+		if buffer.NumSamples == 0 && !positive_step {
+			// Cannot move this index
+			l.Debug().Msg("Cannot step over start index.")
+			return nil
+		}
+	}
 
 	// Get values
 	var currValue uint32
@@ -47,30 +71,59 @@ func (buffer *CircularBuffer) StepIndex(step uint32, marker string, positive_ste
 		nextVal = currValue - step
 	}
 
-	// Check limits and assign value
-	currValue, err := buffer.BufferLimitCheck(nextVal, l)
+	// Check buffer limits
+	nextVal, err := buffer.BufferLimitCheck(nextVal, l)
 	if err != nil {
 		return err
 	}
 
 	// Update values
 	if marker == "start" {
-		buffer.Indexes.Start = currValue
-	} else {
-		if (buffer.Indexes.Start == currValue) && (step > 0) {
-			// This means that the end of the buffer advanced into the start of
-			// the buffer, we must movethe buffer one position
-			buffer.StepIndex(1, "start", true, l)
+
+		if buffer.NumSamples == step && positive_step {
+			// Cannot reduce the buffer anymore, just invalidate last sample
+			buffer.Times[buffer.Indexes.End] = EpochStart
+		} else {
+			buffer.Indexes.Start = nextVal
 		}
-		buffer.Indexes.End = currValue
+
+	} else {
+		if buffer.Indexes.Start == nextVal && positive_step {
+			// This means that the end of the buffer advanced into the start of
+			// the buffer, we must move the buffer one position only if we move
+			// in the positive direction (otherwise we run into the past)
+			if positive_step {
+				buffer.StepIndex(1, "start", true, l)
+
+			}
+			buffer.Indexes.End = nextVal
+		} else if buffer.NumSamples == step && !positive_step {
+			// Cannot reduce the buffer anymore, just invalidate last sample
+			buffer.Times[buffer.Indexes.Start] = EpochStart
+		} else {
+			buffer.Indexes.End = nextVal
+		}
+
 	}
 
 	// Calculate number of valid samples
-	validIdx, err := buffer.GetBufferValidIndexes(l)
-	if err != nil {
-		return err
+	if buffer.Indexes.Start == buffer.Indexes.End {
+		if buffer.Times[buffer.Indexes.Start] != EpochStart {
+			buffer.NumSamples = 1
+		} else {
+			buffer.NumSamples = 0
+		}
+	} else if buffer.Indexes.Start < buffer.Indexes.End {
+		buffer.NumSamples = buffer.Indexes.End - buffer.Indexes.Start
+		if buffer.Times[buffer.Indexes.Start] != EpochStart {
+			buffer.NumSamples += 1
+		}
+	} else {
+		buffer.NumSamples = buffer.CircBufferLen - (buffer.Indexes.Start - buffer.Indexes.End) + 1
+		// if buffer.Times[buffer.Indexes.Start] != EpochStart {
+		// 	buffer.NumSamples += 1
+		// }
 	}
-	buffer.NumSamples = uint32(len(validIdx))
 
 	return nil
 }
@@ -101,15 +154,16 @@ func (buffer *CircularBuffer) CycleIndexes(sampleTTLDays uint32, l *zerolog.Logg
 }
 
 func (buffer *CircularBuffer) BufferLimitCheck(nextVal uint32, l *zerolog.Logger) (uint32, error) {
-	// Check for overflow
-	if nextVal >= buffer.CircBufferLen {
-		nextVal = 0
-	} else if nextVal == math.MaxInt32 {
+
+	if nextVal == math.MaxUint32 {
 		// Check for underflow
 		nextVal = buffer.CircBufferLen - 1
+	} else if nextVal >= buffer.CircBufferLen {
+		// Check for overflow
+		nextVal = 0
 	}
 
-	return uint32(nextVal), nil
+	return nextVal, nil
 }
 
 func (buffer *CircularBuffer) GetBufferValidIndexes(l *zerolog.Logger) (auxIdx []uint32, err error) {
@@ -130,7 +184,7 @@ func (buffer *CircularBuffer) GetBufferValidIndexes(l *zerolog.Logger) (auxIdx [
 		// Check limits and assign value
 		idxNow, err = buffer.BufferLimitCheck(nextVal, l)
 		if err != nil {
-			return auxIdx, err
+			return nil, err
 		}
 	}
 	return auxIdx, err

--- a/apps/go/manager/types/circular_buffer.go
+++ b/apps/go/manager/types/circular_buffer.go
@@ -28,7 +28,11 @@ type CircularBuffer struct {
 // Gets the sample index given a step direction (positive: 1 or negative: -1) and for a given marker (start or end of buffer)
 func (buffer *CircularBuffer) StepIndex(step uint32, marker string, positive_step bool, l *zerolog.Logger) error {
 
-	l.Debug().Int("buffer.Indexes.Start", int(buffer.Indexes.Start)).Int("buffer.Indexes.End", int(buffer.Indexes.End)).Int("step", int(step)).Msg("Circular indexes moving.")
+	l.Debug().
+	  Int("buffer.Indexes.Start", int(buffer.Indexes.Start)).
+	  Int("buffer.Indexes.End", int(buffer.Indexes.End)).
+	  Int("step", int(step)).
+	  Msg("Circular indexes moving.")
 
 	if step > 1 {
 		return fmt.Errorf("Steps of length larger than 1 are not supported.")
@@ -79,14 +83,12 @@ func (buffer *CircularBuffer) StepIndex(step uint32, marker string, positive_ste
 
 	// Update values
 	if marker == "start" {
-
 		if buffer.NumSamples == step && positive_step {
 			// Cannot reduce the buffer anymore, just invalidate last sample
 			buffer.Times[buffer.Indexes.End] = EpochStart
 		} else {
 			buffer.Indexes.Start = nextVal
 		}
-
 	} else {
 		if buffer.Indexes.Start == nextVal && positive_step {
 			// This means that the end of the buffer advanced into the start of
@@ -94,7 +96,6 @@ func (buffer *CircularBuffer) StepIndex(step uint32, marker string, positive_ste
 			// in the positive direction (otherwise we run into the past)
 			if positive_step {
 				buffer.StepIndex(1, "start", true, l)
-
 			}
 			buffer.Indexes.End = nextVal
 		} else if buffer.NumSamples == step && !positive_step {
@@ -103,7 +104,6 @@ func (buffer *CircularBuffer) StepIndex(step uint32, marker string, positive_ste
 		} else {
 			buffer.Indexes.End = nextVal
 		}
-
 	}
 
 	// Calculate number of valid samples
@@ -120,9 +120,7 @@ func (buffer *CircularBuffer) StepIndex(step uint32, marker string, positive_ste
 		}
 	} else {
 		buffer.NumSamples = buffer.CircBufferLen - (buffer.Indexes.Start - buffer.Indexes.End) + 1
-		// if buffer.Times[buffer.Indexes.Start] != EpochStart {
-		// 	buffer.NumSamples += 1
-		// }
+		
 	}
 
 	return nil

--- a/apps/go/manager/types/defaults.go
+++ b/apps/go/manager/types/defaults.go
@@ -1,9 +1,10 @@
 package types
 
 var (
+	DefaultMongodbUri        = "mongodb://127.0.0.1:27017/pocket-ml-testbench?replicaSet=devRs"
+	DefaultTemporalNamespace = "pocket-ml-testbench"
 	DefaultLogLevel          = "info"
 	DefaultTemporalHost      = "localhost"
 	DefaultTemporalPort      = uint(7233)
-	DefaultTemporalNamespace = "default"
 	DefaultTemporalTaskQueue = "node-manager"
 )

--- a/apps/go/manager/workflows/entry.go
+++ b/apps/go/manager/workflows/entry.go
@@ -17,10 +17,15 @@ type Ctx struct {
 var Workflows *Ctx
 
 // SetAppConfig sets the provided app config to the Workflows global variable in the Ctx struct.
-func SetAppConfig(ac *types.App) {
-	Workflows = &Ctx{
-		App: ac,
+func SetAppConfig(ac *types.App) *Ctx {
+	if Workflows != nil {
+		Workflows.App = ac
+	} else {
+		Workflows = &Ctx{
+			App: ac,
+		}
 	}
+	return Workflows
 }
 
 // Register registers the workflows with the provided worker.


### PR DESCRIPTION
Added test suite for the manager, currently only including:
- Tests for `CircularBuffer` struct
- Tests for `NumericalTaskRecord` and `SignatureTaskRecord`, on circular buffer related functionality.