### PR TITLE
Added config for time between relays and a randomization argument

### DIFF
--- a/apps/go/requester/activities/get_tasks.go
+++ b/apps/go/requester/activities/get_tasks.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"requester/types"
+	"time"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"requester/types"
-	"time"
 )
 
 type GetTasksParams struct {
@@ -147,4 +148,25 @@ func (aCtx *Ctx) GetTasks(ctx context.Context, params GetTasksParams) (result *G
 		return nil, aggErr
 	}
 	return
+}
+
+func SplitByUniqueAddress(input []TaskRequest) [][]TaskRequest {
+	// Create a map to store requests with the same address
+	nameToStructs := make(map[string][]TaskRequest)
+
+	// Iterate through the input list
+	for _, s := range input {
+		// Add the request to the corresponding slice in the map
+		nameToStructs[s.Node] = append(nameToStructs[s.Node], s)
+	}
+
+	// Create a slice to store the resulting lists
+	var result [][]TaskRequest
+
+	// Iterate through the map and append each slice to the result
+	for _, structs := range nameToStructs {
+		result = append(result, structs)
+	}
+
+	return result
 }

--- a/apps/go/requester/activities/relayer.go
+++ b/apps/go/requester/activities/relayer.go
@@ -28,8 +28,9 @@ type RelayerParams struct {
 	BlocksPerSession int64  `json:"blocks_per_session"`
 
 	// requester data related
-	PromptId     string  `json:"prompt_id"`
-	RelayTimeout float64 `json:"relay_timeout"`
+	PromptId          string  `json:"prompt_id"`
+	RelayTimeout      float64 `json:"relay_timeout"`
+	RelayTriggerDelay float64 `json:"relay_trigger_delay"`
 }
 
 type RelayerResponse struct {
@@ -139,7 +140,7 @@ func (aCtx *Ctx) Relayer(ctx context.Context, params RelayerParams) (result Rela
 		if err := response.Save(ctx, collection); err != nil {
 			data, err2 := bson.MarshalExtJSON(response, true, false)
 			if err2 != nil {
-				l.Error("Error marshalling relayer response using bson", "error", err2)
+				l.Error("Error marshaling relayer response using bson", "error", err2)
 			} else {
 				l.Error("Error saving relayer response", "error", err, "response", data)
 			}
@@ -239,6 +240,7 @@ func (aCtx *Ctx) Relayer(ctx context.Context, params RelayerParams) (result Rela
 
 	relayerCtx, cancelRelayerFn := context.WithTimeout(ctx, prompt.GetTimeoutDuration()*time.Duration(RelayRetries+1))
 	defer cancelRelayerFn()
+	// Relay to service node is sent here
 	relay, relayErr := relayer.RelayWithCtx(relayerCtx, &relayInput, relayOpts)
 	response.Ms = time.Since(startTime).Milliseconds()
 	if relayErr != nil {

--- a/apps/go/requester/config.sample.json
+++ b/apps/go/requester/config.sample.json
@@ -13,6 +13,10 @@
     "req_per_sec": 10,
     "session_tolerance": 1
   },
+  "relay": {
+    "time_between_relays" : 0.1,
+    "time_dispersion" : 0.05
+  },
   "log_level": "debug",
   "temporal": {
     "host": "localhost",

--- a/apps/go/requester/types/config.go
+++ b/apps/go/requester/types/config.go
@@ -2,8 +2,9 @@ package types
 
 import (
 	"encoding/json"
-	"go.temporal.io/sdk/worker"
 	"time"
+
+	"go.temporal.io/sdk/worker"
 )
 
 type TemporalWorkerOptions struct {
@@ -264,10 +265,16 @@ type RPCConfig struct {
 	SessionTolerance int64    `json:"session_tolerance"`
 }
 
+type RelayConfig struct {
+	TimeBetweenRelays float64 `json:"time_between_relays"`
+	TimeDispersion    float64 `json:"time_dispersion"`
+}
+
 type Config struct {
 	MongodbUri string          `json:"mongodb_uri"`
 	Apps       []string        `json:"apps"`
 	Rpc        *RPCConfig      `json:"rpc"`
+	Relay      *RelayConfig    `json:"relay"`
 	LogLevel   string          `json:"log_level"`
 	Temporal   *TemporalConfig `json:"temporal"`
 }

--- a/apps/go/requester/workflows/relayer.go
+++ b/apps/go/requester/workflows/relayer.go
@@ -25,6 +25,11 @@ var RelayerName = "Relayer"
 func (wCtx *Ctx) Relayer(ctx workflow.Context, params activities.RelayerParams) (results *RelayerResults, e error) {
 	results = &RelayerResults{}
 
+	// Use workflow.Sleep to make the workflow sleep before actually executing the task.
+	// This is to avoid clogging the node with tests
+	workflow.Sleep(ctx, time.Duration(params.RelayTriggerDelay*1000)*time.Millisecond)
+	// Now process and send the relay
+
 	if params.RelayTimeout == 0 {
 		params.RelayTimeout = (time.Duration(120) * time.Second).Seconds()
 	}
@@ -45,6 +50,7 @@ func (wCtx *Ctx) Relayer(ctx workflow.Context, params activities.RelayerParams) 
 		return
 	}
 
+	// Now we will execute the activity that makes the relay to the servicer node
 	relayerResponse := types.RelayResponse{}
 	relayerErr := workflow.ExecuteActivity(relayerCtx, activities.Activities.Relayer, params).Get(relayerCtx, &relayerResponse)
 	if relayerErr != nil {

--- a/docker-compose/dev/apps/config/requester.json
+++ b/docker-compose/dev/apps/config/requester.json
@@ -13,6 +13,10 @@
     "req_per_sec": 3,
     "session_tolerance": 1
   },
+  "relay": {
+    "time_between_relays" : 1,
+    "time_dispersion" : 0.5
+  },
   "log_level": "info",
   "temporal": {
     "host": "temporal",

--- a/docker-compose/dev/apps/config/sampler.json
+++ b/docker-compose/dev/apps/config/sampler.json
@@ -15,12 +15,12 @@
   "timeouts": {
     "default": {
       "ttft": {
-        "x": [
+        "prompt_lenght": [
           0,
           8192,
           32768
         ],
-        "y": [
+        "sla_time": [
           0,
           2,
           10

--- a/docker-compose/morse-poc/apps_configs/requester.json
+++ b/docker-compose/morse-poc/apps_configs/requester.json
@@ -13,6 +13,10 @@
     "req_per_sec": 10,
     "session_tolerance": 1
   },
+  "relay": {
+    "time_between_relays" : 0.1,
+    "time_dispersion" : 0.05
+  },
   "log_level": "info",
   "temporal": {
     "host": "temporal",

--- a/packages/go/pocket_rpc/client_pool.go
+++ b/packages/go/pocket_rpc/client_pool.go
@@ -316,7 +316,6 @@ func (cp *ClientPool) ReplicateRequest(r *http.Request, ctx context.Context, max
 }
 
 func (cp *ClientPool) do(client *Client, req *http.Request, ctx context.Context) (*http.Response, error) {
-	// TODO : Test this rate limiter
 	lim := rate.NewLimiter(rate.Every(time.Second/time.Duration(cp.opts.ReqPerSec)), 1)
 
 	// Wait for the rate limiter

--- a/packages/python/lmeh/pocket_lm_eval/api/task.py
+++ b/packages/python/lmeh/pocket_lm_eval/api/task.py
@@ -872,7 +872,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
                 non_retryable=True,
             )
 
-        where_clause = " AND ".join(conditions)  # TODO : Shouldn't this be AND ??
+        where_clause = " AND ".join(conditions)
         return where_clause
 
     async def get_max_min_ids(self, postgres_conn: asyncpg.Connection, table_name: str):


### PR DESCRIPTION
Added two configurations to the requester:
- `time_between_relays`: Sets the minimum difference (in seconds) between two relays done to the same address
- `time_dispersion` : The range or a randomized additional time added to the request delay, chosen uniformly from  `[0,time_dispersion)`. Value in seconds.

Also, the requests are now sorted by node address. The workflow will look for all pending request tags and create a map containing a separate list for each node requests. For example:
if all fond requests are : `[ReqA, ReqB, ReqC, ReqD]`, with: `ReqA.Node = 1`, `ReqB.Node = 2`, `ReqA.Node = 1` and `ReqD.Node = 1`
they will be sorted as:
```
[ReqA, ReqB, ReqD],
[ReqC]
```
Then each request will be sent with a custom delay equal to:
`ReqIdx*time_between_relays + rand(0,time_dispersion)`
where `ReqIdx` is the index in the list (equal to zero for `ReqA` and `ReqC`, 1 for `ReqB` and 2 for `ReqD`)

CAUTION:
The inclusion of new relays for a given node does not take into account if the node already has pending request tasks. While this could cause congestion of requests in the tested node, it is unlikely to happen as the tasks are loaded faster than the requester pools them, resulting in batchs and not in a streaming of tasks.
