### PR TITLE
106 sidecar allow for model name overriding

### DIFF
--- a/apps/python/sampler/activities/signatures/tokenizer/tokenizer.py
+++ b/apps/python/sampler/activities/signatures/tokenizer/tokenizer.py
@@ -34,7 +34,7 @@ def get_tokenizer_task(
     instance = PocketNetworkMongoDBInstance(task_id=task.id)
     # Create the void prompt
     prompt = PocketNetworkMongoDBPrompt(
-        model_config={}, data="", task_id=task.id, instance_id=instance.id, timeout=60
+        model_config={}, data="", task_id=task.id, instance_id=instance.id, timeout=300
     )
 
     return task, [instance], [prompt]

--- a/apps/python/sidecar/app/initialization.py
+++ b/apps/python/sidecar/app/initialization.py
@@ -8,15 +8,18 @@ import os
 TOKENIZER_EPHIMERAL_PATH = "/tmp/tokenizer_aux"
 CONFIG_EPHIMERAL_PATH = "/tmp/config_aux"
 
+
 def setup_tokenizer_data(tokenizer_path_or_name):
-    '''
-    Reads a tokenizer file from a given model folder or downloads an specified 
+    """
+    Reads a tokenizer file from a given model folder or downloads an specified
     tokenizer from the Huggingface hub.
     It also calculates the tokenizer data hash.
-    '''
+    """
 
     # Read tokenizer data
-    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path_or_name, token=os.getenv("HF_TOKEN", None))
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_path_or_name, token=os.getenv("HF_TOKEN", None)
+    )
     # Process it using the MLTB library (functions are reused by the MLTB)
     TOKENIZER_JSON, TOKENIZER_HASH = prepare_tokenizer(
         tokenizer, TOKENIZER_EPHIMERAL_PATH=TOKENIZER_EPHIMERAL_PATH
@@ -24,8 +27,9 @@ def setup_tokenizer_data(tokenizer_path_or_name):
 
     return TOKENIZER_JSON, TOKENIZER_HASH
 
+
 def setup_model_config_data(config_path, config_data):
-    '''
+    """
     Reads a configuration file from a given model folder or creates an empty one
     using the provided config data.
     The empty configuration is filled with minimal data required by users:
@@ -33,65 +37,68 @@ def setup_model_config_data(config_path, config_data):
     - max_position_embeddings : The total number of tokens accepted by the model (input + output).
 
     It also calculates the resulting config data hash.
-    '''
+    """
 
     if config_path is not None and config_data is not None:
-        raise ValueError("Both \"config_path\" and \"config_data\" cannot be defined. Please define only one in the config file.")
+        raise ValueError(
+            'Both "config_path" and "config_data" cannot be defined. Please define only one in the config file.'
+        )
 
     elif config_path is not None:
         _config = AutoConfig.from_pretrained(config_path)
 
     elif config_data is not None:
         _config = PretrainedConfig(
-            model_name=config_data['model_public_name'],
-            max_position_embeddings=config_data['max_position_embeddings'],
-            pokt_network_custom=True
-            )
+            model_name=config_data["model_public_name"],
+            max_position_embeddings=config_data["max_position_embeddings"],
+            pokt_network_custom=True,
+        )
 
     else:
-        raise ValueError("Both \"config_path\" and \"config_data\" cannot be empty. Please define one in the config file.")
-        
+        raise ValueError(
+            'Both "config_path" and "config_data" cannot be empty. Please define one in the config file.'
+        )
+
     CONFIG_JSON, CONFIG_HASH = prepare_config(
-            _config, CONFIG_EPHIMERAL_PATH='./outputs/test'
-        )    
-    
+        _config, CONFIG_EPHIMERAL_PATH="./outputs/test"
+    )
+
     return CONFIG_JSON, CONFIG_HASH
 
+
 def setup_llm_backend_override(endpoint_override_data):
-    '''
+    """
     Reads the backend endpoint data, sets-up the URI and checks the health.
-    '''
+    """
 
     LLM_BACKEND_ENDPOINT = None
     LLM_BACKEND_MODEL_NAME = None
 
     if endpoint_override_data is None:
-        print("LLM backend overriding not configured.")    
+        print("LLM backend overriding not configured.")
     else:
         LLM_BACKEND_ENDPOINT = endpoint_override_data["backend_path"]
         LLM_BACKEND_MODEL_NAME = endpoint_override_data["backend_model_name"]
 
         # Check LLM backend health, should get a 200
         default_headers = {
-                'Content-Type': 'application/json',
-                'Authorization' : os.getenv("BACKEND_TOKEN") # In case backend is gated
-            }
+            "Content-Type": "application/json",
+            "Authorization": os.getenv("BACKEND_TOKEN"),  # In case backend is gated
+        }
         req = requests.post(
             f"{LLM_BACKEND_ENDPOINT}/v1/completions",
             headers=default_headers,
             # auth=auth, TODO : Implement auths, for openAI and such
-            data=json.dumps({
-                "prompt": "123456",
-                "max_tokens":2, 
-                "model":LLM_BACKEND_MODEL_NAME
-            })
+            data=json.dumps(
+                {"prompt": "123456", "max_tokens": 2, "model": LLM_BACKEND_MODEL_NAME}
+            ),
         )
 
         if req.status_code == 200:
             print("Backend healthy!")
         else:
-            raise ValueError(f"Testing the \"/v1/completions\" endpoint resulted in a non 200 status code:\nstatus: {req.status_code}\nresponse: {req.json}")
-        
-
+            raise ValueError(
+                f'Testing the "/v1/completions" endpoint resulted in a non 200 status code:\nstatus: {req.status_code}\nresponse: {req.json}'
+            )
 
     return LLM_BACKEND_ENDPOINT, LLM_BACKEND_MODEL_NAME

--- a/apps/python/sidecar/app/initialization.py
+++ b/apps/python/sidecar/app/initialization.py
@@ -1,0 +1,97 @@
+from transformers import AutoConfig, AutoTokenizer, PretrainedConfig
+
+from packages.python.lmeh.utils.tokenizers import prepare_config, prepare_tokenizer
+import requests
+import json
+import os
+
+TOKENIZER_EPHIMERAL_PATH = "/tmp/tokenizer_aux"
+CONFIG_EPHIMERAL_PATH = "/tmp/config_aux"
+
+def setup_tokenizer_data(tokenizer_path_or_name):
+    '''
+    Reads a tokenizer file from a given model folder or downloads an specified 
+    tokenizer from the Huggingface hub.
+    It also calculates the tokenizer data hash.
+    '''
+
+    # Read tokenizer data
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path_or_name, token=os.getenv("HF_TOKEN", None))
+    # Process it using the MLTB library (functions are reused by the MLTB)
+    TOKENIZER_JSON, TOKENIZER_HASH = prepare_tokenizer(
+        tokenizer, TOKENIZER_EPHIMERAL_PATH=TOKENIZER_EPHIMERAL_PATH
+    )
+
+    return TOKENIZER_JSON, TOKENIZER_HASH
+
+def setup_model_config_data(config_path, config_data):
+    '''
+    Reads a configuration file from a given model folder or creates an empty one
+    using the provided config data.
+    The empty configuration is filled with minimal data required by users:
+    - model_public_name : A name that will be public, can be any string.
+    - max_position_embeddings : The total number of tokens accepted by the model (input + output).
+
+    It also calculates the resulting config data hash.
+    '''
+
+    if config_path is not None and config_data is not None:
+        raise ValueError("Both \"config_path\" and \"config_data\" cannot be defined. Please define only one in the config file.")
+
+    elif config_path is not None:
+        _config = AutoConfig.from_pretrained(config_path)
+
+    elif config_data is not None:
+        _config = PretrainedConfig(
+            model_name=config_data['model_public_name'],
+            max_position_embeddings=config_data['max_position_embeddings'],
+            pokt_network_custom=True
+            )
+
+    else:
+        raise ValueError("Both \"config_path\" and \"config_data\" cannot be empty. Please define one in the config file.")
+        
+    CONFIG_JSON, CONFIG_HASH = prepare_config(
+            _config, CONFIG_EPHIMERAL_PATH='./outputs/test'
+        )    
+    
+    return CONFIG_JSON, CONFIG_HASH
+
+def setup_llm_backend_override(endpoint_override_data):
+    '''
+    Reads the backend endpoint data, sets-up the URI and checks the health.
+    '''
+
+    LLM_BACKEND_ENDPOINT = None
+    LLM_BACKEND_MODEL_NAME = None
+
+    if endpoint_override_data is None:
+        print("LLM backend overriding not configured.")    
+    else:
+        LLM_BACKEND_ENDPOINT = endpoint_override_data["backend_path"]
+        LLM_BACKEND_MODEL_NAME = endpoint_override_data["backend_model_name"]
+
+        # Check LLM backend health, should get a 200
+        default_headers = {
+                'Content-Type': 'application/json',
+                'Authorization' : os.getenv("BACKEND_TOKEN") # In case backend is gated
+            }
+        req = requests.post(
+            f"{LLM_BACKEND_ENDPOINT}/v1/completions",
+            headers=default_headers,
+            # auth=auth, TODO : Implement auths, for openAI and such
+            data=json.dumps({
+                "prompt": "123456",
+                "max_tokens":2, 
+                "model":LLM_BACKEND_MODEL_NAME
+            })
+        )
+
+        if req.status_code == 200:
+            print("Backend healthy!")
+        else:
+            raise ValueError(f"Testing the \"/v1/completions\" endpoint resulted in a non 200 status code:\nstatus: {req.status_code}\nresponse: {req.json}")
+        
+
+
+    return LLM_BACKEND_ENDPOINT, LLM_BACKEND_MODEL_NAME

--- a/apps/python/sidecar/app/overrides.py
+++ b/apps/python/sidecar/app/overrides.py
@@ -2,36 +2,37 @@ import aiohttp
 from typing import Dict, Any
 import os
 
-def replace_model_name(json_request, override):
 
-    if json_request.get('model', None) is None:
+def replace_model_name(json_request, override):
+    if json_request.get("model", None) is None:
         return None
     else:
-        json_request['model'] = override
-    
+        json_request["model"] = override
+
     return json_request
 
-async def do_request(url: str, path: str, payload: Dict[str, Any], headers: Dict[str, str] = None, timeout: int = 600) -> Dict[str, Any]:
 
-    
+async def do_request(
+    url: str,
+    path: str,
+    payload: Dict[str, Any],
+    headers: Dict[str, str] = None,
+    timeout: int = 600,
+) -> Dict[str, Any]:
     # Default headers
-    default_headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-    }
+    default_headers = {"Content-Type": "application/json", "Accept": "application/json"}
     # In case backend is gated
     access_token = os.getenv("BACKEND_TOKEN", None)
     if access_token is not None:
-        default_headers['Authorization'] = access_token  
-        
-    
+        default_headers["Authorization"] = access_token
+
     # Merge default headers with custom headers
     request_headers = {**default_headers, **(headers or {})}
-    
+
     async with aiohttp.ClientSession() as session:
         try:
             async with session.post(
-                url+path,
+                url + path,
                 headers=request_headers,
                 json=payload,
                 # Optional configurations
@@ -46,7 +47,7 @@ async def do_request(url: str, path: str, payload: Dict[str, Any], headers: Dict
                     print(f"Response body: {error_text}")
                     response.raise_for_status()
                 return await response.json()
-                
+
         except aiohttp.ClientError as e:
             print(f"Request failed: {str(e)}")
             raise

--- a/apps/python/sidecar/app/overrides.py
+++ b/apps/python/sidecar/app/overrides.py
@@ -18,6 +18,8 @@ async def do_request(
     payload: Dict[str, Any],
     headers: Dict[str, str] = None,
     timeout: int = 600,
+    error_on_not_OK: bool = False,
+    logger: Any = None,
 ) -> Dict[str, Any]:
     # Default headers
     default_headers = {"Content-Type": "application/json", "Accept": "application/json"}
@@ -42,10 +44,15 @@ async def do_request(
                 # Raise an exception for bad status codes
                 if not response.ok:
                     error_text = await response.text()
-                    print(f"\nError {response.status}")
-                    print(f"URL: {url}")
-                    print(f"Response body: {error_text}")
-                    response.raise_for_status()
+                    if logger is not None:
+                        logger.debug(
+                            "Request NOT OK",
+                            status=response.status,
+                            url=url,
+                            error_text=error_text,
+                        )
+                    if error_on_not_OK:
+                        response.raise_for_status()
                 return await response.json()
 
         except aiohttp.ClientError as e:

--- a/apps/python/sidecar/app/overrides.py
+++ b/apps/python/sidecar/app/overrides.py
@@ -1,0 +1,52 @@
+import aiohttp
+from typing import Dict, Any
+import os
+
+def replace_model_name(json_request, override):
+
+    if json_request.get('model', None) is None:
+        return None
+    else:
+        json_request['model'] = override
+    
+    return json_request
+
+async def do_request(url: str, path: str, payload: Dict[str, Any], headers: Dict[str, str] = None, timeout: int = 600) -> Dict[str, Any]:
+
+    
+    # Default headers
+    default_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+    # In case backend is gated
+    access_token = os.getenv("BACKEND_TOKEN", None)
+    if access_token is not None:
+        default_headers['Authorization'] = access_token  
+        
+    
+    # Merge default headers with custom headers
+    request_headers = {**default_headers, **(headers or {})}
+    
+    async with aiohttp.ClientSession() as session:
+        try:
+            async with session.post(
+                url+path,
+                headers=request_headers,
+                json=payload,
+                # Optional configurations
+                timeout=timeout,  # 30 seconds timeout
+                # ssl=True    # Enable SSL verification
+            ) as response:
+                # Raise an exception for bad status codes
+                if not response.ok:
+                    error_text = await response.text()
+                    print(f"\nError {response.status}")
+                    print(f"URL: {url}")
+                    print(f"Response body: {error_text}")
+                    response.raise_for_status()
+                return await response.json()
+                
+        except aiohttp.ClientError as e:
+            print(f"Request failed: {str(e)}")
+            raise

--- a/apps/python/sidecar/config.sample.json
+++ b/apps/python/sidecar/config.sample.json
@@ -1,4 +1,13 @@
 {
   "log_level": "DEBUG",
-  "tokenizer_path": "/tokenizer"
+  "llm_endpoint_override": {
+    "backend_model_name" : "mane_of_actual_deployed_model_used_in_API",
+    "backend_path" : "http://lala:9999"
+  },
+  "tokenizer_path_or_name": "/tokenizer",
+  "model_config_path": "/tokenizer",
+  "model_config_data": {
+    "model_public_name" : "any_name_you_want_to_use",
+    "max_position_embeddings" : 4096
+  }
 }

--- a/apps/python/sidecar/config.sample.json
+++ b/apps/python/sidecar/config.sample.json
@@ -4,8 +4,8 @@
     "backend_model_name" : "mane_of_actual_deployed_model_used_in_API",
     "backend_path" : "http://lala:9999"
   },
-  "tokenizer_path_or_name": "/tokenizer",
-  "model_config_path": "/tokenizer",
+  "tokenizer_path_or_name": "/model",
+  "model_config_path": "/model",
   "model_config_data": {
     "model_public_name" : "any_name_you_want_to_use",
     "max_position_embeddings" : 4096

--- a/apps/python/sidecar/main.py
+++ b/apps/python/sidecar/main.py
@@ -1,7 +1,11 @@
 from app.app import get_app_logger, setup_app
 from app.config import read_config
 from app.overrides import replace_model_name, do_request
-from app.initialization import setup_tokenizer_data, setup_model_config_data, setup_llm_backend_override
+from app.initialization import (
+    setup_tokenizer_data,
+    setup_model_config_data,
+    setup_llm_backend_override,
+)
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 
@@ -19,12 +23,15 @@ logger.info("starting sidecar")
 
 
 # Load tokenizer data
-TOKENIZER_JSON, TOKENIZER_HASH = setup_tokenizer_data(config['tokenizer_path_or_name'])
+TOKENIZER_JSON, TOKENIZER_HASH = setup_tokenizer_data(config["tokenizer_path_or_name"])
 # Load or create model config data
-CONFIG_JSON, CONFIG_HASH = setup_model_config_data(config.get("model_config_path", None), 
-                                                   config.get("model_config_data", None))
+CONFIG_JSON, CONFIG_HASH = setup_model_config_data(
+    config.get("model_config_path", None), config.get("model_config_data", None)
+)
 # Get overriding name, the actual name of the deployed model
-LLM_BACKEND_ENDPOINT, LLM_BACKEND_MODEL_NAME = setup_llm_backend_override(config.get("llm_endpoint_override", None))
+LLM_BACKEND_ENDPOINT, LLM_BACKEND_MODEL_NAME = setup_llm_backend_override(
+    config.get("llm_endpoint_override", None)
+)
 
 # Create serving app
 app = FastAPI()
@@ -70,7 +77,6 @@ def get_config_hash():
     return JSONResponse({"hash": CONFIG_HASH})
 
 
-
 ###################################################
 # OVERRIDING ENDPOINTS
 ###################################################
@@ -78,37 +84,37 @@ def get_config_hash():
 async def override_v1_completitions(request: Request):
     logger.debug("overriding /v1/completions")
     if LLM_BACKEND_ENDPOINT is None:
-        raise HTTPException(status_code=501, detail="Backend LLM overriding is not configured.")
+        raise HTTPException(
+            status_code=501, detail="Backend LLM overriding is not configured."
+        )
 
-    # load 
+    # load
     data = await request.json()
 
     # replace model name
     data = replace_model_name(data, LLM_BACKEND_MODEL_NAME)
 
     # call model endpoint
-    response = await do_request(LLM_BACKEND_ENDPOINT, 
-                                "/v1/completions", 
-                                data)
+    response = await do_request(LLM_BACKEND_ENDPOINT, "/v1/completions", data)
     # return
     return JSONResponse(response)
+
 
 @app.post("/v1/chat/completions")
-async def override_v1_completitions(request: Request):
+async def override_v1_chat_completitions(request: Request):
     logger.debug("overriding /v1/chat/completions")
     if LLM_BACKEND_ENDPOINT is None:
-        raise HTTPException(status_code=501, detail="Backend LLM overriding is not configured.")
+        raise HTTPException(
+            status_code=501, detail="Backend LLM overriding is not configured."
+        )
 
-    # load 
+    # load
     data = await request.json()
 
     # replace model name
     data = replace_model_name(data, LLM_BACKEND_MODEL_NAME)
 
     # call model endpoint
-    response = await do_request(LLM_BACKEND_ENDPOINT, 
-                                "/v1/chat/completions", 
-                                data)
+    response = await do_request(LLM_BACKEND_ENDPOINT, "/v1/chat/completions", data)
     # return
     return JSONResponse(response)
-

--- a/apps/python/sidecar/requirements.txt
+++ b/apps/python/sidecar/requirements.txt
@@ -3,3 +3,4 @@ requests==2.32.2
 fastapi==0.103.0
 transformers==4.47.0
 structlog==24.1.0
+aiohttp==3.9.3

--- a/docker-compose/dev/llm-engine/sidecar/sidecar.json
+++ b/docker-compose/dev/llm-engine/sidecar/sidecar.json
@@ -1,4 +1,9 @@
 {
   "log_level": "INFO",
-  "tokenizer_path": "/tokenizer"
+  "llm_endpoint_override": {
+    "backend_model_name" : "pocket_network",
+    "backend_path" : "http://llm-engine:8000"
+  },
+  "tokenizer_path_or_name": "/tokenizer",
+  "model_config_path": "/tokenizer"
 }

--- a/docker-compose/morse-poc/dependencies_configs/sidecar/sidecar.json
+++ b/docker-compose/morse-poc/dependencies_configs/sidecar/sidecar.json
@@ -1,4 +1,5 @@
 {
   "log_level": "INFO",
-  "tokenizer_path": "/tokenizer"
+  "tokenizer_path_or_name": "/tokenizer",
+  "model_config_path": "/tokenizer"
 }

--- a/packages/python/lmeh/pocket_lm_eval/api/task.py
+++ b/packages/python/lmeh/pocket_lm_eval/api/task.py
@@ -872,7 +872,11 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
                 non_retryable=True,
             )
 
-        where_clause = " AND ".join(conditions)
+        # This is OR because this function is used to retrieve all the samples
+        # to test and all samples from the other splits. So, the result is a 
+        # query with the samples to tests and the other splits (probably used 
+        # for fewshots)
+        where_clause = " OR ".join(conditions)
         return where_clause
 
     async def get_max_min_ids(self, postgres_conn: asyncpg.Connection, table_name: str):

--- a/packages/python/lmeh/pocket_lm_eval/api/task.py
+++ b/packages/python/lmeh/pocket_lm_eval/api/task.py
@@ -873,8 +873,8 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
             )
 
         # This is OR because this function is used to retrieve all the samples
-        # to test and all samples from the other splits. So, the result is a 
-        # query with the samples to tests and the other splits (probably used 
+        # to test and all samples from the other splits. So, the result is a
+        # query with the samples to tests and the other splits (probably used
         # for fewshots)
         where_clause = " OR ".join(conditions)
         return where_clause

--- a/packages/python/lmeh/utils/tokenizers.py
+++ b/packages/python/lmeh/utils/tokenizers.py
@@ -180,8 +180,10 @@ def load_config(
             json.dump(value, f)
             f.close()
 
-    if config_objects['config'].get('pokt_network_custom',None) is not None:
-        _config = PretrainedConfig.from_json_file(os.path.join(config_ephimeral_path, "config.json"))
+    if config_objects["config"].get("pokt_network_custom", None) is not None:
+        _config = PretrainedConfig.from_json_file(
+            os.path.join(config_ephimeral_path, "config.json")
+        )
     else:
         _config = AutoConfig.from_pretrained(
             config_ephimeral_path, trust_remote_code=trust_remote_code

--- a/packages/python/lmeh/utils/tokenizers.py
+++ b/packages/python/lmeh/utils/tokenizers.py
@@ -180,9 +180,12 @@ def load_config(
             json.dump(value, f)
             f.close()
 
-    _config = AutoConfig.from_pretrained(
-        config_ephimeral_path, trust_remote_code=trust_remote_code
-    )
+    if config_objects['config'].get('pokt_network_custom',None) is not None:
+        _config = PretrainedConfig.from_json_file(os.path.join(config_ephimeral_path, "config.json"))
+    else:
+        _config = AutoConfig.from_pretrained(
+            config_ephimeral_path, trust_remote_code=trust_remote_code
+        )
     try:
         shutil.rmtree(config_ephimeral_path)
         if eval_logger is not None:


### PR DESCRIPTION
Now the Sidecar can override the model name from the request allowing arbitrary models on the backend. The process is not designed for performance (see #109 ).
Also the Sidecar accepts a tokenizer name (from huggingface) to be used as the model tokenizer. Any model can be downloaded, the user should match it to the provided model. 
Likewise the configuration can be created from a custom set of parameters that includes only those needed by the testbench (namely the context length).

Other modifications were also bundled here:
- Now the `packages/python/lmeh/utils/tokenizers.py` accepts arbitrary `PretrainedConfig` configs if the node provides a JSON with the `pokt_network_custom` entry.
- The Sampler uses two new optional environment variables, `HF_TOKEN` the Huggingface token requiered to download some tokenizers and the `BACKEND_TOKEN` used to provide an `Authorization` header to the backend (like OpenAI API).
- The tokenizer task timeout was increased, tokenizers can weight a lot (see #111 ). 
- There was a confusion around the SQL query to retrieve a dataset. Now the composition was changed back to `OR` and a proper explanation was written on why it should be like that. 