### PR TITLE
openAI working

### DIFF
--- a/apps/go/manager/records/task.go
+++ b/apps/go/manager/records/task.go
@@ -623,7 +623,7 @@ func (record *NumericalTaskRecord) NewTask(supplierID primitive.ObjectID, framew
 	record.TaskData.SupplierID = supplierID
 	record.TaskData.Framework = framework
 	record.TaskData.Task = task
-	record.TaskData.LastSeen = time.Now().UTC()
+	record.TaskData.LastSeen = time.Now().UTC() // This delays all timed schedules but is needed by the TTL of mongo
 
 	record.MeanScore = 0.0
 	record.MedianScore = 0.0

--- a/apps/go/requester/types/external_suppliers.go
+++ b/apps/go/requester/types/external_suppliers.go
@@ -4,14 +4,16 @@ const ExternalSupplierIdentifier = "external_"
 const ExternalServiceName = "external"
 
 type ExternalSupplierData struct {
-	Endpoint string            `json:"endpoint"`
-	Headers  map[string]string `json:"headers"`
+	Endpoint            string            `json:"endpoint"`
+	Headers             map[string]string `json:"headers"`
+	ModelName           string            `json:"model"`
+	ServiceTier         string            `json:"service_tier"`
+	TemperatureOverride float32           `json:"temperature_override"`
+	NoStop              bool              `json:"no_stop"`
 
-	// TODO : Add support for these, specifically ModelName blocks any provider
-	// 		  that is not a pocket gateway
+	// TODO : Add support for these
 
 	// ApiType       string            `json:"api_type"`
-	// ModelName string `json:"model_name"`
 	// ContextLength int64             `json:"context_length"`
 	// Timeout       int64             `json:"timeout"`
 }

--- a/packages/python/lmeh/pocket_lm_eval/models/pocket_network.py
+++ b/packages/python/lmeh/pocket_lm_eval/models/pocket_network.py
@@ -800,6 +800,11 @@ class SamplerChatCompletionAPI(SamplerAPI, LocalChatCompletion):
             eos=self.eos_string,
             **kwargs,
         )
+        # Fixing deprecated max_tokens, replacing with max_completion_tokens
+        max_toks = request.get("max_tokens", None)
+        if max_toks is not None:
+            request.pop("max_tokens")
+            request["max_completion_tokens"] = max_toks
         # Return CompletionRequest instance
         return ChatCompletionRequest(**request)
 

--- a/tilt/apps/manager/local/patches/secret.template.yaml
+++ b/tilt/apps/manager/local/patches/secret.template.yaml
@@ -16,7 +16,7 @@ stringData:
       "pocket_blocks_per_session" : 10,
       "log_level": "debug",
       "develop": {
-        "do_not_remove_tasks_from_db" : false
+        "do_not_remove_tasks_from_db" : true
       },
       "temporal": {
         "host": "temporal-service",
@@ -53,7 +53,7 @@ stringData:
         "lmeh-generative" : {
           "task_types": {"any" : "numerical"},
           "task_dependency": {"any" : ["none:none:none"]},
-          "schedule_limits": {"any" : "5:minutes"},
+          "schedule_limits": {"any" : "none:none"},
           "trigger_minimum": {"any" : "0"},
           "taxonomy_dependency": {"any" : ["none:none:none:none"]}
         },


### PR DESCRIPTION
Added support for OpenAI, specifically tested with `gpt-5-mini`.
This included:
- Modification/override of parameter `max_tokens` into `max_completion_tokens`
- Added `model` as required parameter for external sources.
- Added `service_tier` as optional parameter (used for `flex` tier in OpenAI)
- Added `temperature_override` to change the specified temperature from test (`o` models do not support temperature).
- Added `no_stop` to remove stop tokens specification, this is not supported by the tested model.