### PR TITLE
[Feature] Task sample tracking

### DIFF
--- a/apps/go/manager/activities/process_supplier_result.go
+++ b/apps/go/manager/activities/process_supplier_result.go
@@ -175,6 +175,11 @@ func (aCtx *Ctx) AnalyzeResult(ctx context.Context, params types.AnalyzeResultPa
 			thisTaskRecord.UpdateLastHeight(thisTaskResults.GetResultHeight())
 			thisTaskRecord.UpdateLastSeen(thisTaskResults.GetResultTime())
 
+			// Track the successful sample if requested
+			if aCtx.App.Config.TrackSuccessfulSamples {
+				TrackTaskID(supplierData.Address, params.TaskID, thisTaskResults, aCtx.App.Mongodb, l)
+			}
+
 		}
 
 	} else {
@@ -328,4 +333,163 @@ func RemoveTaskID(taskID primitive.ObjectID, mongoDB mongodb.MongoDb, l *zerolog
 		l.Debug().Int("deleted_count", int(response.DeletedCount)).Str("TaskID", taskID.String()).Msg("deleted task data from MongoDB")
 	}
 
+}
+
+// Given a TaskID from MongoDB, creates a tracking entry in collection "tracked_tasks".
+// This collection will include several entries per taskID, specifically it will look all the entries in the "instances"
+// collection associated with the taskID and collect for each:
+// - From the "instances" collection:
+//   - `doc_id`
+//   - `task_name`
+//
+// - From the "prompts" collection (matching both the `task_id` and the `instance_id`):
+//   - the `data` field (which we will call `prompt`)
+//
+// - From the "responses" collection (matching both the `task_id` and the `instance_id`):
+//   - `response`
+//   - the `ms` field (which we will call `response_ms`)
+//
+// - From the "results" collection (matching the `task_id`):
+//   - the `score` field of the `scores` vector that matches the the `id` with the `doc_id` being processed.
+//
+// Finally we will save all this data into the collection "tracked_tasks" as a new entry containing all fields:
+//
+//	`doc_id`, `task_name`, `prompt`, `response`, `response_ms`, `score`
+func TrackTaskID(supplierAddress string, taskID primitive.ObjectID, taskResults records.ResultInterface, mongoDB mongodb.MongoDb, l *zerolog.Logger) {
+
+	l.Debug().Str("TaskID", taskID.String()).Msg("Tracking task sample.")
+
+	//--------------------------------------------------------------------------
+	//-------------------------- Get Instances --------------------------------
+	//--------------------------------------------------------------------------
+	instancesCollection := mongoDB.GetCollection(types.InstanceCollection)
+	instanceFilter := bson.D{{Key: "task_id", Value: taskID}}
+	ctxM, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	cursor, err := instancesCollection.Find(ctxM, instanceFilter)
+	if err != nil {
+		l.Warn().Err(err).Msg("Could not find instances from MongoDB.")
+		return
+	}
+	defer cursor.Close(ctxM)
+
+	var instances []types.Instance
+	if err = cursor.All(ctxM, &instances); err != nil {
+		l.Warn().Err(err).Msg("Could not decode instances from MongoDB.")
+		return
+	}
+
+	if len(instances) == 0 {
+		l.Debug().Str("TaskID", taskID.String()).Msg("No instances found for task.")
+		return
+	}
+
+	//--------------------------------------------------------------------------
+	//-------------------------- Get Prompts, Responses & Scores ---------------
+	//--------------------------------------------------------------------------
+	promptsCollection := mongoDB.GetCollection(types.PromptsCollection)
+	responsesCollection := mongoDB.GetCollection(types.ResponsesCollection)
+	trackedTasksCollection := mongoDB.GetCollection(types.TackedTaskSamplesCollection)
+
+	var trackedTasks []*types.TrackedTaskSample
+
+	// Iterate through each instance
+	for _, instance := range instances {
+
+		// Get the prompt for this instance
+		promptFilter := bson.D{
+			{Key: "task_id", Value: taskID},
+			{Key: "instance_id", Value: instance.Id},
+		}
+		ctxM, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		var prompt types.Prompt
+		promptCursor := promptsCollection.FindOne(ctxM, promptFilter)
+		err := promptCursor.Decode(&prompt)
+		if err != nil {
+			l.Warn().Err(err).Str("instance_id", instance.Id.String()).Msg("Could not find prompt for instance.")
+			continue
+		}
+
+		// Get the response for this instance
+		responseFilter := bson.D{
+			{Key: "task_id", Value: taskID},
+			{Key: "instance_id", Value: instance.Id},
+		}
+		ctxM, cancel = context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		var response types.RelayResponse
+		responseCursor := responsesCollection.FindOne(ctxM, responseFilter)
+		err = responseCursor.Decode(&response)
+		if err != nil {
+			l.Warn().Err(err).Str("instance_id", instance.Id.String()).Msg("Could not find response for instance.")
+			continue
+		}
+
+		// Find the score that matches the doc_id from the task results
+		var matchingScore float64
+		found := false
+		for i := 0; i < int(taskResults.GetNumSamples()); i++ {
+			sample := taskResults.GetSample(i)
+			scoresSample, ok := sample.(records.ScoresSample)
+			if !ok {
+				// Skip non-numerical samples or samples that cannot be type asserted
+				l.Debug().
+					Int("idx", i).
+					Int64("doc_id", instance.DocID).
+					Str("task_id", taskID.String()).
+					Msg("Skipping non-numerical sample.")
+				continue
+			}
+			if scoresSample.ID == int(instance.DocID) {
+				matchingScore = scoresSample.Score
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			l.Warn().Int64("doc_id", instance.DocID).Str("task_id", taskID.String()).Msg("No matching score found for doc_id.")
+			continue
+		}
+
+		// Build the tracked task document
+		trackedTask := &types.TrackedTaskSample{
+			SupplierAddress: supplierAddress,
+			DocID:           instance.DocID,
+			TaskName:        instance.TaskName,
+			Prompt:          prompt.Data,
+			Response:        response.Response,
+			ResponseMs:      response.Ms,
+			Score:           matchingScore,
+			SampleDate:      time.Now(),
+		}
+
+		trackedTasks = append(trackedTasks, trackedTask)
+	}
+
+	if len(trackedTasks) == 0 {
+		l.Debug().Str("TaskID", taskID.String()).Msg("No tracked tasks to insert.")
+		return
+	}
+
+	// Insert all tracked tasks
+	ctxM, cancel = context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Convert to []interface{} for InsertMany
+	interfaceSlice := make([]interface{}, len(trackedTasks))
+	for i, v := range trackedTasks {
+		interfaceSlice[i] = v
+	}
+
+	result, err := trackedTasksCollection.InsertMany(ctxM, interfaceSlice)
+	if err != nil {
+		l.Warn().Err(err).Msg("Could not insert tracked tasks into MongoDB.")
+	} else {
+		l.Debug().Int("inserted_count", len(result.InsertedIDs)).Str("TaskID", taskID.String()).Msg("Inserted tracked tasks into MongoDB")
+	}
 }

--- a/apps/go/manager/config.sample.json
+++ b/apps/go/manager/config.sample.json
@@ -33,6 +33,7 @@
       "task_queue": "sampler-local"
     }
   },
+  "track_successful_samples": true,
   "frameworks": {
     "lmeh-generative-liveness" : {
       "task_types": {"any" : "numerical"},

--- a/apps/go/manager/types/config.go
+++ b/apps/go/manager/types/config.go
@@ -234,6 +234,7 @@ type Config struct {
 	Apps                   map[string]string          `json:"pocket_apps"`
 	Services               []string                   `json:"pocket_services"`
 	ExternalSuppliers      []string                   `json:"external_suppliers"`
+	TrackSuccessfulSamples bool                       `json:"track_successful_samples"`
 }
 
 type FrameworkConfig struct {

--- a/apps/go/manager/types/mongodb.go
+++ b/apps/go/manager/types/mongodb.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
 var (
 	TaskCollection              = "tasks"
 	InstanceCollection          = "instances"
@@ -10,4 +16,47 @@ var (
 	NumericalTaskCollection     = "buffers_numerical"
 	SignaturesTaskCollection    = "buffers_signatures"
 	TaxonomySummariesCollection = "taxonomy_summaries"
+	TackedTaskSamplesCollection = "tracked_task_samples"
 )
+
+type RelayResponse struct {
+	Id       primitive.ObjectID `bson:"_id"`
+	Ok       bool               `bson:"ok"`
+	Code     int                `bson:"error_code"`
+	Ms       int64              `bson:"ms"`
+	Response string             `bson:"response"`
+	Error    string             `bson:"error"`
+	// cross references
+	TaskId     primitive.ObjectID `bson:"task_id"`
+	InstanceId primitive.ObjectID `bson:"instance_id"`
+	PromptId   primitive.ObjectID `bson:"prompt_id"`
+}
+
+type Instance struct {
+	Id       primitive.ObjectID `bson:"_id"`
+	TaskName string             `bson:"task_name"`
+	DocID    int64              `bson:"doc_id"`
+	Done     bool               `bson:"done"`
+	// -- Relations Below --
+	// id and/or entity if load with a $lookup
+	TaskId primitive.ObjectID `bson:"task_id"`
+}
+
+type Prompt struct {
+	Id   primitive.ObjectID `bson:"_id"`
+	Data string             `bson:"data"`
+	// -- Relations Below --
+	TaskId     primitive.ObjectID `bson:"task_id"`
+	InstanceId primitive.ObjectID `bson:"instance_id"`
+}
+
+type TrackedTaskSample struct {
+	SupplierAddress string    `bson:"supplier_address"`
+	DocID           int64     `bson:"doc_id"`
+	TaskName        string    `bson:"task_name"`
+	Prompt          string    `bson:"prompt"`
+	Response        string    `bson:"response"`
+	ResponseMs      int64     `bson:"response_ms"`
+	Score           float64   `bson:"score"`
+	SampleDate      time.Time `bson:"sample_date"`
+}

--- a/apps/go/manager/workflows/supplier_manager.go
+++ b/apps/go/manager/workflows/supplier_manager.go
@@ -89,6 +89,10 @@ func (wCtx *Ctx) SupplierManager(ctx workflow.Context, params types.SupplierMana
 	// -------------------------------------------------------------------------
 	// -------------------- Get Randomness Seed --------------------------------
 	// -------------------------------------------------------------------------
+	// TODO: Make this configurable. Currently all tasks triggered will sample
+	//       the same docs (if possible due to blacklist). This is something you
+	//		 may want for signatures or an ordered test, but makes the testing
+	//		 process easier to detect by the backends.
 	var randomSeed int
 	ctxTimeout := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		ScheduleToStartTimeout: time.Second * 5,

--- a/apps/go/manager/x/app.go
+++ b/apps/go/manager/x/app.go
@@ -93,6 +93,7 @@ func Initialize() *types.App {
 		types.NumericalTaskCollection,
 		types.SignaturesTaskCollection,
 		types.TaxonomySummariesCollection,
+		types.TackedTaskSamplesCollection,
 	}, l)
 
 	// Create LazyNode

--- a/apps/python/evaluator/activities/lmeh/evaluate.py
+++ b/apps/python/evaluator/activities/lmeh/evaluate.py
@@ -188,6 +188,9 @@ async def lmeh_evaluate(args: PocketNetworkEvaluationTaskRequest) -> Tuple[bool,
                             verbosity=str(args.verbosity),
                             predict_only=False,
                             eval_logger=eval_logger,
+                            random_seed= args.random_seed,
+                            numpy_random_seed= args.random_seed,
+                            fewshot_random_seed= args.random_seed,
                             metadata=metadata,
                         )
                     except ApplicationError as e:

--- a/apps/python/evaluator/activities/lmeh/evaluate.py
+++ b/apps/python/evaluator/activities/lmeh/evaluate.py
@@ -157,6 +157,9 @@ async def lmeh_evaluate(args: PocketNetworkEvaluationTaskRequest) -> Tuple[bool,
                     metadata=metadata,
                     pocket_args=args,
                     stage=TASK_MANAGER_EVALUATE_STAGE,
+                    random_seed=args.random_seed,
+                    numpy_random_seed=args.random_seed,
+                    fewshot_random_seed=args.random_seed,
                 )
                 eval_logger.debug("Read task names", task_names=task_names)
 
@@ -188,9 +191,9 @@ async def lmeh_evaluate(args: PocketNetworkEvaluationTaskRequest) -> Tuple[bool,
                             verbosity=str(args.verbosity),
                             predict_only=False,
                             eval_logger=eval_logger,
-                            random_seed= args.random_seed,
-                            numpy_random_seed= args.random_seed,
-                            fewshot_random_seed= args.random_seed,
+                            random_seed=args.random_seed,
+                            numpy_random_seed=args.random_seed,
+                            fewshot_random_seed=args.random_seed,
                             metadata=metadata,
                         )
                     except ApplicationError as e:

--- a/apps/python/sampler/activities/lmeh/sample.py
+++ b/apps/python/sampler/activities/lmeh/sample.py
@@ -115,6 +115,9 @@ async def lmeh_sample(args: PocketNetworkTaskRequest) -> bool:
                 metadata=metadata,
                 pocket_args=args,
                 stage=TASK_MANAGER_SAMPLE_STAGE,
+                random_seed=args.random_seed,
+                numpy_random_seed=args.random_seed,
+                fewshot_random_seed=args.random_seed,
             )
             eval_logger.debug("Read task names", task_names=task_names)
 
@@ -187,9 +190,9 @@ async def lmeh_sample(args: PocketNetworkTaskRequest) -> bool:
                         verbosity=str(args.verbosity),
                         predict_only=False,
                         eval_logger=eval_logger,
-                        random_seed= args.random_seed,
-                        numpy_random_seed= args.random_seed,
-                        fewshot_random_seed= args.random_seed,
+                        random_seed=args.random_seed,
+                        numpy_random_seed=args.random_seed,
+                        fewshot_random_seed=args.random_seed,
                         metadata=metadata,
                     )
                 except ApplicationError as e:
@@ -217,7 +220,7 @@ async def lmeh_sample(args: PocketNetworkTaskRequest) -> bool:
                 # load dataset from database
                 try:
                     # it is loading data from sql to a dataset
-                    await task_dict[task_name].load_from_sql()
+                    await task_dict[task_name].load_from_sql(args.random_seed)
                     eval_logger.info("Task loaded successfully:", task_dict=task_dict)
                 except ApplicationError as e:
                     raise e

--- a/apps/python/sampler/activities/lmeh/sample.py
+++ b/apps/python/sampler/activities/lmeh/sample.py
@@ -187,6 +187,9 @@ async def lmeh_sample(args: PocketNetworkTaskRequest) -> bool:
                         verbosity=str(args.verbosity),
                         predict_only=False,
                         eval_logger=eval_logger,
+                        random_seed= args.random_seed,
+                        numpy_random_seed= args.random_seed,
+                        fewshot_random_seed= args.random_seed,
                         metadata=metadata,
                     )
                 except ApplicationError as e:

--- a/packages/python/lmeh/pocket_lm_eval/api/task.py
+++ b/packages/python/lmeh/pocket_lm_eval/api/task.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import random
 import time
 from collections.abc import Callable
 from typing import (
@@ -545,8 +546,14 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         await streamer.transfer(self.config.dataset_kwargs)
 
     async def load_from_sql(
-        self, dataset_kwargs: Optional[Dict[str, Any]] = None
+        self, random_seed=None, dataset_kwargs: Optional[Dict[str, Any]] = None
     ) -> None:
+        # Set random seed
+        if random_seed is not None:
+            random.seed(random_seed)
+            np.random.seed(random_seed)
+            self.eval_logger.debug("Random seeds set to", random_seed=random_seed)
+
         qty = self._config.metadata["pocket_args"].qty
         doc_ids = self.config.metadata["pocket_args"].doc_ids
         blacklist = self._config.metadata["pocket_args"].blacklist
@@ -599,6 +606,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
                     _range["min"],
                     _range["max"],
                     blacklist,
+                    random_seed=random_seed,
                 )
 
         where_clause = self.get_SQL_where_clause(indexes, _split, _split_ranges)
@@ -917,6 +925,7 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         min: int,
         max: int,
         blacklist: List[int] = [],
+        random_seed: int = None,
     ) -> List[int]:
         """
         This function generates a list of random numbers within a range, excluding some blacklisted numbers
@@ -938,30 +947,42 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
 
         # Generate a list of random numbers within the range [min, max]
         ints = set(range(min, max + 1))
-        if blacklist is not None:
-            # exclude the blacklist members
-            if len(blacklist) > 0:
-                original_len = len(ints)
-                # Remove the blacklisted numbers
-                ints = ints - set(blacklist)
-                # Check that the blacklist numbers were removed
-                if len(ints) == original_len:
-                    self.eval_logger.error(
-                        "Blacklist out of range:",
-                        table_name=table_name,
-                        _split=_split,
-                        range_min=min,
-                        range_max=max,
-                        blacklist=blacklist,
-                    )
-                    raise ApplicationError(
-                        "Blacklist corresponding to '{}' table & '{}' split were not founded in the range: [{}-{}]".format(
-                            table_name, _split, min, max
-                        ),
-                        non_retryable=True,
-                    )
-        # sorted random numbers
-        choices = sorted(np.random.choice(list(ints), qty, replace=False).tolist())
+
+        # Convert to list and shuffle the list
+        ints = list(ints)
+        ints = sorted(ints)  # Make sure the starting list order is deterministic
+        random.seed(random_seed)  # Set this here otherwise it fails?
+        random.shuffle(ints)
+
+        self.eval_logger.debug("Original rand list", ints=ints)
+        # Apply the blacklist if any
+        # This will break the controlled randomness, but not always (this is the best we can do).
+        if blacklist is not None and len(blacklist) > 0:
+            original_len = len(ints)
+            # Remove the blacklisted numbers
+            for remove_int in blacklist:
+                ints.remove(remove_int)
+
+            # Check that the blacklist numbers were removed
+            if len(ints) == original_len:
+                self.eval_logger.error(
+                    "Blacklist out of range:",
+                    table_name=table_name,
+                    _split=_split,
+                    range_min=min,
+                    range_max=max,
+                    blacklist=blacklist,
+                )
+                raise ApplicationError(
+                    "Blacklist corresponding to '{}' table & '{}' split were not founded in the range: [{}-{}]".format(
+                        table_name, _split, min, max
+                    ),
+                    non_retryable=True,
+                )
+        # Pick the number we need from the top of the shuffled list
+        choices = ints[:qty]
+        # sort the list
+        choices = sorted(choices)
         self.eval_logger.debug("Random numbers generated:", choices=choices)
         return choices
 

--- a/packages/python/lmeh/pocket_lm_eval/api/task.py
+++ b/packages/python/lmeh/pocket_lm_eval/api/task.py
@@ -951,7 +951,9 @@ class PocketNetworkConfigurableTask(ConfigurableTask):
         # Convert to list and shuffle the list
         ints = list(ints)
         ints = sorted(ints)  # Make sure the starting list order is deterministic
-        random.seed(random_seed)  # Set this here otherwise it fails?
+        random.seed(
+            random_seed
+        )  # Set this here otherwise it fails to be reproducible? No idea why...
         random.shuffle(ints)
 
         self.eval_logger.debug("Original rand list", ints=ints)

--- a/packages/python/lmeh/utils/common.py
+++ b/packages/python/lmeh/utils/common.py
@@ -12,6 +12,7 @@ from packages.python.lmeh.pocket_lm_eval.tasks import (
     PocketNetworkTaskManager,
 )
 from packages.python.protocol.protocol import PocketNetworkTaskRequest
+from lm_eval.defaults import DEFAULT_OTHER_SEED, DEFAULT_RANDOM_SEED
 
 
 def get_task_manager(
@@ -23,10 +24,10 @@ def get_task_manager(
     metadata: Optional[dict] = None,
     pocket_args: Optional[PocketNetworkTaskRequest] = None,
     stage: Optional[STAGE_TYPING] = None,
-    random_seed: Optional[int] = None,
-    numpy_random_seed: Optional[int] = None,
-    torch_random_seed: Optional[int] = None,
-    fewshot_random_seed: int = 1234,
+    random_seed: int = DEFAULT_RANDOM_SEED,
+    numpy_random_seed: int = DEFAULT_OTHER_SEED,
+    torch_random_seed: int = DEFAULT_OTHER_SEED,
+    fewshot_random_seed: int = DEFAULT_OTHER_SEED,
     hf_token: Optional[str] = None,
 ):
     """

--- a/packages/python/lmeh/utils/common.py
+++ b/packages/python/lmeh/utils/common.py
@@ -26,7 +26,6 @@ def get_task_manager(
     stage: Optional[STAGE_TYPING] = None,
     random_seed: int = DEFAULT_RANDOM_SEED,
     numpy_random_seed: int = DEFAULT_OTHER_SEED,
-    torch_random_seed: int = DEFAULT_OTHER_SEED,
     fewshot_random_seed: int = DEFAULT_OTHER_SEED,
     hf_token: Optional[str] = None,
 ):

--- a/packages/python/lmeh/utils/generator.py
+++ b/packages/python/lmeh/utils/generator.py
@@ -69,7 +69,6 @@ def get_configurable_task(
     eval_logger: Optional[logging.Logger] = None,
     random_seed: int = DEFAULT_RANDOM_SEED,
     numpy_random_seed: int = DEFAULT_OTHER_SEED,
-    # torch_random_seed: int = DEFAULT_OTHER_SEED,
     fewshot_random_seed: int = DEFAULT_OTHER_SEED,
     metadata: Optional[dict] = None,
 ):
@@ -100,10 +99,6 @@ def get_configurable_task(
     if numpy_random_seed is not None:
         seed_message.append(f"Setting numpy seed to {numpy_random_seed}")
         np.random.seed(numpy_random_seed)
-
-    # if torch_random_seed is not None:
-    #     seed_message.append(f"Setting torch manual seed to {torch_random_seed}")
-    #     set_torch_seed(torch_random_seed)
 
     if fewshot_random_seed is not None:
         seed_message.append(f"Setting fewshot manual seed to {fewshot_random_seed}")

--- a/packages/python/lmeh/utils/generator.py
+++ b/packages/python/lmeh/utils/generator.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, List, Optional, Union
-
+import random
 from lm_eval.evaluator_utils import (
     get_sample_size,
     run_task_tests,
@@ -14,6 +14,7 @@ from lm_eval.utils import (
     positional_deprecated,
     simple_parse_args_string,
 )
+from lm_eval.defaults import DEFAULT_OTHER_SEED, DEFAULT_RANDOM_SEED
 
 import numpy as np
 
@@ -66,7 +67,10 @@ def get_configurable_task(
     verbosity: str = "ERROR",
     predict_only: bool = False,
     eval_logger: Optional[logging.Logger] = None,
-    fewshot_random_seed: Optional[int] = None,
+    random_seed: int = DEFAULT_RANDOM_SEED,
+    numpy_random_seed: int = DEFAULT_OTHER_SEED,
+    # torch_random_seed: int = DEFAULT_OTHER_SEED,
+    fewshot_random_seed: int = DEFAULT_OTHER_SEED,
     metadata: Optional[dict] = None,
 ):
     """Instantiate and evaluate a model on a list of tasks.
@@ -88,6 +92,21 @@ def get_configurable_task(
     """
 
     seed_message = []
+    if random_seed is not None:
+        # See https://github.com/EleutherAI/lm-evaluation-harness/pull/1412
+        seed_message.append(f"Setting random seed to {random_seed}")
+        random.seed(random_seed)
+
+    if numpy_random_seed is not None:
+        seed_message.append(f"Setting numpy seed to {numpy_random_seed}")
+        np.random.seed(numpy_random_seed)
+
+    # if torch_random_seed is not None:
+    #     seed_message.append(f"Setting torch manual seed to {torch_random_seed}")
+    #     set_torch_seed(torch_random_seed)
+
+    if fewshot_random_seed is not None:
+        seed_message.append(f"Setting fewshot manual seed to {fewshot_random_seed}")
 
     if seed_message:
         eval_logger.debug(" | ".join(seed_message))

--- a/tilt/apps/commons/base/configmap.yaml
+++ b/tilt/apps/commons/base/configmap.yaml
@@ -44,7 +44,7 @@ data:
       },
       "t-eval_pnyx_instruct-v2": {
           "metrics": ["call_match"],
-          "filters": ["instruct_extract"],
+          "filters": ["function_instruct_extract"],
           "doc_as_chat_template": true,
           "apply_chat_template": false,
           "fewshot_as_multiturn": false
@@ -58,7 +58,7 @@ data:
       },
       "t-eval_pnyx_plan-json-v2": {
           "metrics": ["plan_f1_score"],
-          "filters": ["call_extract"],
+          "filters": ["function_call_extract"],
           "doc_as_chat_template": true,
           "apply_chat_template": false,
           "fewshot_as_multiturn": false
@@ -72,7 +72,7 @@ data:
       },
       "t-eval_pnyx_plan-reason-retrieve-understand-json-v2": {
           "metrics": ["call_match"],
-          "filters": ["call_extract"],
+          "filters": ["function_call_extract"],
           "doc_as_chat_template": true,
           "apply_chat_template": false,
           "fewshot_as_multiturn": false

--- a/tilt/apps/evaluator/base/deployment.yaml
+++ b/tilt/apps/evaluator/base/deployment.yaml
@@ -35,6 +35,8 @@ spec:
               value: "True"
             - name: HF_DATASETS_DISABLE_PROGRESS_BARS
               value: "True"
+            - name : HF_ALLOW_CODE_EVAL
+              value: "1"
             - name: OPENAI_API_KEY
               valueFrom:
                   secretKeyRef:

--- a/tilt/apps/manager/local/patches/secret.template.yaml
+++ b/tilt/apps/manager/local/patches/secret.template.yaml
@@ -35,6 +35,7 @@ stringData:
           "task_queue": "sampler"
         }
       },
+      "track_successful_samples": true,
       "frameworks": {
         "lmeh-generative-liveness" : {
           "task_types": {"any" : "numerical"},

--- a/tilt/apps/sampler/base/deployment.yaml
+++ b/tilt/apps/sampler/base/deployment.yaml
@@ -35,6 +35,8 @@ spec:
               value: "True"
             - name: HF_DATASETS_DISABLE_PROGRESS_BARS
               value: "True"
+            - name : HF_ALLOW_CODE_EVAL
+              value: "1"
             - name: OPENAI_API_KEY
               valueFrom:
                   secretKeyRef:

--- a/tilt/dependencies/mongodb/base/configmap.yaml
+++ b/tilt/dependencies/mongodb/base/configmap.yaml
@@ -71,3 +71,5 @@ data:
     db.identity_summaries.createIndex({"supplier_id": 1}, {unique: true});
 
     db.createCollection('suppliers_snapshots');
+
+    db.createCollection('tracked_task_samples');


### PR DESCRIPTION
A new configuration parameter is introduced: `track_successful_samples` if set to `true` it will track all task samples' responses and results into a new collection called `tracked_task_samples`. For each tested sample an entry will be created, containing:
```go
type TrackedTaskSample struct {
	SupplierAddress string    `bson:"supplier_address"` // The pocket address or external service name
	DocID           int64     `bson:"doc_id"` // The id of the task sample
	TaskName        string    `bson:"task_name"` // The name of the task
	Prompt          string    `bson:"prompt"` // The complete prompt sent to the backend
	Response        string    `bson:"response"` // The complete response received
	ResponseMs      int64     `bson:"response_ms"` // The time it took the backend to answer
	Score           float64   `bson:"score"` // The score of the evaluation (normally a number between 0.0 and 1.0)
	SampleDate      time.Time `bson:"sample_date"` // The date this sample was created
}
```
(currently only numerical tasks are tracked this way)

Additional changes:
- Now the random seed setting is working for numerical tasks. This required some change in the sampling logic. Now all docs sampled with the same manager trigger are coordinated (if random behavior is preferred, a TODO was left in the place where it needs to be implemented).
- The env var `HF_ALLOW_CODE_EVAL` was missing (needed for debugbench).
- Fixed names of filters for t-eval config in Tilt.