### PR TITLE
Added taxonomy data tracking

### DIFF
--- a/apps/python/summarizer/app/app.py
+++ b/apps/python/summarizer/app/app.py
@@ -1,5 +1,7 @@
 import logging
 import asyncpg
+import datetime
+import networkx as nx
 from packages.python.common.mongodb import MongoClient
 from packages.python.common.utils import get_from_dict
 from packages.python.logger.logger import get_logger
@@ -17,6 +19,42 @@ app_config = {
     # fill with taxonomies graphs here
     "taxonomies": None,
 }
+
+
+async def _ensure_taxonomy_in_mongodb(
+    mongo_client: MongoClient, taxonomy_graph, taxonmy_file_name: str, logger
+):
+    """
+    Checks if a taxonomy entry exists in the MongoDB 'tracked_taxonomies' collection
+    (matching by file name). If not, creates one with the node names, their
+    datasets, and the adjacency matrix (nodes sorted alphabetically).
+    """
+    tax_collection = mongo_client.db["tracked_taxonomies"]
+    existing = await tax_collection.find_one({"name": taxonmy_file_name})
+    if existing is None:
+        # Get datasets per node
+        nodes_data = txm_utils.get_taxonomy_datasets_per_node(taxonomy_graph)
+        # Convert to a list of node names with their datasets
+        nodes_list = [
+            {"name": node, "datasets": datasets}
+            for node, datasets in nodes_data.items()
+        ]
+        # Compute adjacency matrix with alphabetically sorted nodes (excluding root_c)
+        sorted_nodes = sorted([n for n in taxonomy_graph.nodes() if n != "root_c"])
+        adjacency_matrix = nx.to_numpy_array(
+            taxonomy_graph, nodelist=sorted_nodes
+        ).tolist()
+        # Insert into MongoDB
+        await tax_collection.insert_one(
+            {
+                "name": taxonmy_file_name,
+                "graph_name": taxonomy_graph.name,
+                "nodes": nodes_list,
+                "adjacency_matrix": adjacency_matrix,
+                "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            }
+        )
+        logger.info(f"Inserted taxonomy metadata into MongoDB for: {taxonmy_file_name}")
 
 
 async def setup_app(cfg) -> dict:
@@ -75,6 +113,10 @@ async def setup_app(cfg) -> dict:
                 app_config["taxonomies"][taxonomy_graph.name] = taxonomy_graph
                 logger.info(
                     f"Added taxonomy to track: {taxonmy_file_name} ({taxonomy_graph.name})"
+                )
+
+                await _ensure_taxonomy_in_mongodb(
+                    mongo_client, taxonomy_graph, taxonmy_file_name, logger
                 )
 
     if tax_use is not None and len(app_config["taxonomies"]) == 0:

--- a/apps/python/summarizer/app/app.py
+++ b/apps/python/summarizer/app/app.py
@@ -22,7 +22,7 @@ app_config = {
 
 
 async def _ensure_taxonomy_in_mongodb(
-    mongo_client: MongoClient, taxonomy_graph, taxonmy_file_name: str, logger
+    mongo_client: MongoClient, taxonomy_graph, taxonomy_file_name: str, logger
 ):
     """
     Checks if a taxonomy entry exists in the MongoDB 'tracked_taxonomies' collection
@@ -30,7 +30,7 @@ async def _ensure_taxonomy_in_mongodb(
     datasets, and the adjacency matrix (nodes sorted alphabetically).
     """
     tax_collection = mongo_client.db["tracked_taxonomies"]
-    existing = await tax_collection.find_one({"name": taxonmy_file_name})
+    existing = await tax_collection.find_one({"name": taxonomy_file_name})
     if existing is None:
         # Get datasets per node
         nodes_data = txm_utils.get_taxonomy_datasets_per_node(taxonomy_graph)
@@ -47,14 +47,16 @@ async def _ensure_taxonomy_in_mongodb(
         # Insert into MongoDB
         await tax_collection.insert_one(
             {
-                "name": taxonmy_file_name,
+                "name": taxonomy_file_name,
                 "graph_name": taxonomy_graph.name,
                 "nodes": nodes_list,
                 "adjacency_matrix": adjacency_matrix,
                 "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             }
         )
-        logger.info(f"Inserted taxonomy metadata into MongoDB for: {taxonmy_file_name}")
+        logger.info(
+            f"Inserted taxonomy metadata into MongoDB for: {taxonomy_file_name}"
+        )
 
 
 async def setup_app(cfg) -> dict:
@@ -98,25 +100,25 @@ async def setup_app(cfg) -> dict:
         tax_use = tax_use.split(",")
     for file in os.listdir(tax_path):
         file_path = Path(os.path.join(tax_path, file))
-        taxonmy_file_name = file_path.stem
+        taxonomy_file_name = file_path.stem
         file_ext = file_path.suffix
-        logger.debug(f"Checking: {taxonmy_file_name}{file_ext}.")
+        logger.debug(f"Checking: {taxonomy_file_name}{file_ext}.")
         if ".tax" == file_ext:
             if tax_use is None or file in tax_use:
                 taxonomy_graph = txm_utils.load_taxonomy(
                     os.path.join(tax_path, file), return_all=False, verbose=True
                 )
-                if taxonomy_graph.name != taxonmy_file_name:
+                if taxonomy_graph.name != taxonomy_file_name:
                     logger.debug(
-                        f'WARNING : Taxonomy file name is different from taxonomy graph name ("{taxonmy_file_name}" vs "{taxonomy_graph.name}"). Using GRAPH NAME as taxonomy name.'
+                        f'WARNING : Taxonomy file name is different from taxonomy graph name ("{taxonomy_file_name}" vs "{taxonomy_graph.name}"). Using GRAPH NAME as taxonomy name.'
                     )
                 app_config["taxonomies"][taxonomy_graph.name] = taxonomy_graph
                 logger.info(
-                    f"Added taxonomy to track: {taxonmy_file_name} ({taxonomy_graph.name})"
+                    f"Added taxonomy to track: {taxonomy_file_name} ({taxonomy_graph.name})"
                 )
 
                 await _ensure_taxonomy_in_mongodb(
-                    mongo_client, taxonomy_graph, taxonmy_file_name, logger
+                    mongo_client, taxonomy_graph, taxonomy_file_name, logger
                 )
 
     if tax_use is not None and len(app_config["taxonomies"]) == 0:

--- a/tilt/dependencies/mongodb/base/configmap.yaml
+++ b/tilt/dependencies/mongodb/base/configmap.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -73,3 +74,5 @@ data:
     db.createCollection('suppliers_snapshots');
 
     db.createCollection('tracked_task_samples');
+
+    db.createCollection('tracked_taxonomies');


### PR DESCRIPTION
Now in MongoDB there is a collection called `tracked_taxonomies` that will include the following data of each taxonomy being summarized:
- `name`: Name of the taxonomy file (without `.tax`). Used to track the exact source of the configuration.
- `graph_name`: Name of the stored graph (actual taxonomy name)
- `nodes`: A dictionary containing the taxonomy node's names and for each node the list of tasks that it requieres.
- `adjacency_matrix`: The adjacency matrix, with nodes sorted alphabetically and without the `root_c` node.
- `created_at`: Date of the record entry.

The data is added when the `Summarizer` is started.