### PR TITLE
New buffer maintenance workflow

### DIFF
--- a/apps/go/manager/activities/analyze_supplier.go
+++ b/apps/go/manager/activities/analyze_supplier.go
@@ -55,47 +55,8 @@ func (aCtx *Ctx) AnalyzeSupplier(ctx context.Context, params types.AnalyzeSuppli
 	//--------------------------------------------------------------------------
 	// Update all tasks buffers
 	//--------------------------------------------------------------------------
-	var LastSeenHeight int64
-	var LastSeenTime time.Time
-	if !found {
-		// Create entry in MongoDB
-		l.Debug().Bool("found", found).Msg("Creating empty supplier entry.")
-		err = thisSupplierData.Init(params, aCtx.App.Config.Frameworks, aCtx.App.Mongodb, l)
-		if err != nil {
-			l.Error().Err(err).
-				Str("address", params.Supplier.Address).
-				Str("service", params.Supplier.Service).
-				Msg("Failed to create supplier entry.")
-			return nil, err
-		}
-		result.IsNew = true
-		LastSeenHeight = currHeight
-		LastSeenTime = currTime
-
-	} else {
-		// If the supplier entry exist we must cycle and check for pending results
-		LastSeenHeight, LastSeenTime, err = updateTasksSupplier(&thisSupplierData, params.Tests, aCtx.App.Config.Frameworks, aCtx.App.Mongodb, l)
-		if err != nil {
-			l.Error().
-				Err(err).
-				Str("address", params.Supplier.Address).
-				Str("service", params.Supplier.Service).
-				Msg("Failed to create update supplier.")
-			return nil, err
-		}
-	}
-
-	// Do general update of supplier
-	thisSupplierData.LastProcessHeight = currHeight
-	thisSupplierData.LastProcessTime = currTime
-	thisSupplierData.LastSeenHeight = LastSeenHeight
-	thisSupplierData.LastSeenTime = LastSeenTime
-
-	// Push to DB the supplier data
-	l.Debug().Msg("Uploading supplier changes to DB.")
-	_, err = thisSupplierData.UpdateSupplier(aCtx.App.Mongodb, l)
+	result.IsNew, err = UpdateSupplierData(&thisSupplierData, found, params.Supplier, params.Tests, aCtx.App.Config.Frameworks, aCtx.App.Mongodb, l, currHeight, currTime)
 	if err != nil {
-		l.Error().Err(err).Str("address", params.Supplier.Address).Str("service", params.Supplier.Service).Msg("Failed upload supplier to MongoDB.")
 		return nil, err
 	}
 
@@ -240,6 +201,68 @@ func (aCtx *Ctx) AnalyzeSupplier(ctx context.Context, params types.AnalyzeSuppli
 	return &result, nil
 }
 
+// UpdateSupplierData - Updates the supplier record buffers and timestamps.
+// If the supplier is not found it will initialize a new entry.
+func UpdateSupplierData(
+	supplierData *records.SupplierRecord,
+	found bool,
+	supplier types.SupplierData,
+	tests []types.TestsData,
+	frameworkConfigMap map[string]types.FrameworkConfig,
+	mongoDB mongodb.MongoDb,
+	l *zerolog.Logger,
+	currHeight int64,
+	currTime time.Time,
+) (isNew bool, err error) {
+
+	var LastSeenHeight int64
+	var LastSeenTime time.Time
+
+	if !found {
+		// Create entry in MongoDB
+		l.Debug().Bool("found", found).Msg("Creating empty supplier entry.")
+		err = supplierData.Init(types.AnalyzeSupplierParams{Supplier: supplier, Tests: tests}, frameworkConfigMap, mongoDB, l)
+		if err != nil {
+			l.Error().Err(err).
+				Str("address", supplier.Address).
+				Str("service", supplier.Service).
+				Msg("Failed to create supplier entry.")
+			return false, err
+		}
+		isNew = true
+		LastSeenHeight = currHeight
+		LastSeenTime = currTime
+
+	} else {
+		// If the supplier entry exist we must cycle and check for pending results
+		LastSeenHeight, LastSeenTime, err = updateTasksSupplier(supplierData, tests, frameworkConfigMap, mongoDB, l)
+		if err != nil {
+			l.Error().
+				Err(err).
+				Str("address", supplier.Address).
+				Str("service", supplier.Service).
+				Msg("Failed to create update supplier.")
+			return false, err
+		}
+	}
+
+	// Do general update of supplier
+	supplierData.LastProcessHeight = currHeight
+	supplierData.LastProcessTime = currTime
+	supplierData.LastSeenHeight = LastSeenHeight
+	supplierData.LastSeenTime = LastSeenTime
+
+	// Push to DB the supplier data
+	l.Debug().Msg("Uploading supplier changes to DB.")
+	_, err = supplierData.UpdateSupplier(mongoDB, l)
+	if err != nil {
+		l.Error().Err(err).Str("address", supplier.Address).Str("service", supplier.Service).Msg("Failed upload supplier to MongoDB.")
+		return false, err
+	}
+
+	return isNew, nil
+}
+
 // Checks for suppliers's tasks records and drops old ones.
 func updateTasksSupplier(supplierData *records.SupplierRecord,
 	tests []types.TestsData,
@@ -299,6 +322,24 @@ func updateTasksSupplier(supplierData *records.SupplierRecord,
 			// Update task in DB
 			//------------------------------------------------------------------
 			if cycled || found {
+				l.Debug().
+					Str("address", supplierData.Address).
+					Str("service", supplierData.Service).
+					Str("framework", test.Framework).
+					Str("task", task).
+					Msg("Recalculating task metrics.")
+				err = thisTaskRecord.ProcessData(l)
+				if err != nil {
+					l.Error().
+						Err(err).
+						Str("address", supplierData.Address).
+						Str("service", supplierData.Service).
+						Str("framework", test.Framework).
+						Str("task", task).
+						Msg("Failed to recalculate task metrics.")
+					return LastSeenHeight, LastSeenTime, err
+				}
+
 				l.Debug().
 					Str("address", supplierData.Address).
 					Str("service", supplierData.Service).

--- a/apps/go/manager/activities/entry.go
+++ b/apps/go/manager/activities/entry.go
@@ -51,4 +51,16 @@ func (aCtx *Ctx) Register(w worker.Worker) {
 		Name: AnalyzeResultName,
 	})
 
+	w.RegisterActivityWithOptions(aCtx.GetAllSuppliers, activity.RegisterOptions{
+		Name: GetAllSuppliersName,
+	})
+
+	w.RegisterActivityWithOptions(aCtx.UpdateSupplierBuffers, activity.RegisterOptions{
+		Name: UpdateSupplierBuffersName,
+	})
+
+	w.RegisterActivityWithOptions(aCtx.GetSupplierTests, activity.RegisterOptions{
+		Name: GetSupplierTestsName,
+	})
+
 }

--- a/apps/go/manager/activities/get_all_suppliers.go
+++ b/apps/go/manager/activities/get_all_suppliers.go
@@ -1,0 +1,21 @@
+package activities
+
+import (
+	"context"
+	"manager/records"
+	"manager/types"
+)
+
+var GetAllSuppliersName = "get_all_suppliers"
+
+func (aCtx *Ctx) GetAllSuppliers(ctx context.Context) (*types.GetAllSuppliersResults, error) {
+	l := aCtx.App.Logger
+	l.Debug().Msg("Getting all suppliers from DB.")
+
+	suppliers, err := records.GetAllSuppliers(aCtx.App.Mongodb, l)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.GetAllSuppliersResults{Suppliers: suppliers}, nil
+}

--- a/apps/go/manager/activities/get_supplier_tests.go
+++ b/apps/go/manager/activities/get_supplier_tests.go
@@ -1,0 +1,49 @@
+package activities
+
+import (
+	"context"
+	"manager/records"
+	"manager/types"
+)
+
+var GetSupplierTestsName = "get_supplier_tests"
+
+func (aCtx *Ctx) GetSupplierTests(ctx context.Context, params types.GetSupplierTestsParams) (*types.GetSupplierTestsResults, error) {
+	l := aCtx.App.Logger
+	l.Debug().
+		Str("address", params.Supplier.Address).
+		Str("service", params.Supplier.Service).
+		Msg("Retrieving supplier tests from DB.")
+
+	// Retrieve this supplier entry to get its ObjectID
+	var thisSupplierData records.SupplierRecord
+	found, err := thisSupplierData.FindAndLoadSupplier(params.Supplier, aCtx.App.Mongodb, l)
+	if err != nil {
+		l.Error().
+			Err(err).
+			Str("address", params.Supplier.Address).
+			Str("service", params.Supplier.Service).
+			Msg("Failed to load supplier data.")
+		return nil, err
+	}
+
+	if !found {
+		l.Warn().
+			Str("address", params.Supplier.Address).
+			Str("service", params.Supplier.Service).
+			Msg("Supplier not found in DB, returning empty tests.")
+		return &types.GetSupplierTestsResults{Tests: []types.TestsData{}}, nil
+	}
+
+	tests, err := records.GetAllTasksForSupplier(thisSupplierData.ID, aCtx.App.Mongodb, l)
+	if err != nil {
+		l.Error().
+			Err(err).
+			Str("address", params.Supplier.Address).
+			Str("service", params.Supplier.Service).
+			Msg("Failed to retrieve tasks for supplier.")
+		return nil, err
+	}
+
+	return &types.GetSupplierTestsResults{Tests: tests}, nil
+}

--- a/apps/go/manager/activities/update_supplier_buffers.go
+++ b/apps/go/manager/activities/update_supplier_buffers.go
@@ -1,0 +1,61 @@
+package activities
+
+import (
+	"context"
+	"manager/records"
+	"manager/types"
+	"time"
+)
+
+var UpdateSupplierBuffersName = "update_supplier_buffers"
+
+func (aCtx *Ctx) UpdateSupplierBuffers(ctx context.Context, params types.UpdateSupplierBuffersParams) (*types.UpdateSupplierBuffersResults, error) {
+	l := aCtx.App.Logger
+	l.Debug().
+		Str("address", params.Supplier.Address).
+		Str("service", params.Supplier.Service).
+		Msg("Updating supplier buffers.")
+
+	// Get current height and time
+	currHeight, err := aCtx.App.PocketFullNode.GetLatestBlockHeight()
+	if err != nil {
+		l.Error().
+			Str("supplier", params.Supplier.Address).
+			Str("service", params.Supplier.Service).
+			Msg("Could not retrieve latest block height.")
+		return nil, err
+	}
+	currTime := time.Now()
+
+	// Retrieve this supplier entry
+	var thisSupplierData records.SupplierRecord
+	found, err := thisSupplierData.FindAndLoadSupplier(params.Supplier, aCtx.App.Mongodb, l)
+	if err != nil {
+		l.Error().
+			Err(err).
+			Str("address", params.Supplier.Address).
+			Str("service", params.Supplier.Service).
+			Msg("Failed to load supplier data.")
+		return nil, err
+	}
+
+	if !found {
+		l.Warn().
+			Str("address", params.Supplier.Address).
+			Str("service", params.Supplier.Service).
+			Msg("Supplier not found in DB, skipping buffer update.")
+		return &types.UpdateSupplierBuffersResults{Success: false}, nil
+	}
+
+	_, err = UpdateSupplierData(&thisSupplierData, true, params.Supplier, params.Tests, aCtx.App.Config.Frameworks, aCtx.App.Mongodb, l, currHeight, currTime)
+	if err != nil {
+		l.Error().
+			Err(err).
+			Str("address", params.Supplier.Address).
+			Str("service", params.Supplier.Service).
+			Msg("Failed to update supplier buffers.")
+		return &types.UpdateSupplierBuffersResults{Success: false}, err
+	}
+
+	return &types.UpdateSupplierBuffersResults{Success: true}, nil
+}

--- a/apps/go/manager/records/supplier.go
+++ b/apps/go/manager/records/supplier.go
@@ -128,3 +128,36 @@ func (record *SupplierRecord) UpdateSupplier(mongoDB mongodb.MongoDb, l *zerolog
 
 	return found, nil
 }
+
+// GetAllSuppliers retrieves all supplier records from the database.
+func GetAllSuppliers(mongoDB mongodb.MongoDb, l *zerolog.Logger) ([]types.SupplierData, error) {
+	// Get suppliers collection
+	suppliersCollection := mongoDB.GetCollection(types.SuppliersCollection)
+
+	// Set mongo context
+	ctxM, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Retrieve all supplier entries
+	cursor, err := suppliersCollection.Find(ctxM, bson.D{})
+	if err != nil {
+		l.Error().Err(err).Msg("Could not retrieve all suppliers from MongoDB.")
+		return nil, err
+	}
+	defer cursor.Close(ctxM)
+
+	var results []types.SupplierData
+	for cursor.Next(ctxM) {
+		var record SupplierRecord
+		if err := cursor.Decode(&record); err != nil {
+			l.Error().Err(err).Msg("Could not decode supplier data from MongoDB.")
+			return nil, err
+		}
+		results = append(results, types.SupplierData{
+			Address: record.Address,
+			Service: record.Service,
+		})
+	}
+
+	return results, nil
+}

--- a/apps/go/manager/records/task.go
+++ b/apps/go/manager/records/task.go
@@ -834,10 +834,15 @@ func (record *NumericalTaskRecord) GetNumOkSamples() uint32 {
 	// Initialize a counter for the number of OK samples
 	var okSamples uint32 = 0
 
+	maxAge := time.Duration(record.GetSampleTTLDays()) * 24 * time.Hour
 	// Loop through all the elements of `ScoresSamples` and count the number that have `StatusCode==0`
 	// and checking if the element index is within the valid range using the function "IsIndexInRange(uint32)"
+	// and that the sample is not past its TTL.
 	for i, sample := range record.ScoresSamples {
-		if record.CircBuffer.IsIndexInRange(uint32(i)) && sample.StatusCode == 0 {
+		idx := uint32(i)
+		if record.CircBuffer.IsIndexInRange(idx) && sample.StatusCode == 0 &&
+			record.CircBuffer.Times[idx] != types.EpochStart &&
+			time.Since(record.CircBuffer.Times[idx]) < maxAge {
 			okSamples++
 		}
 	}
@@ -865,7 +870,7 @@ func (record *NumericalTaskRecord) IsEqual(data interface{}) (statusOK bool, err
 func (record *NumericalTaskRecord) ProcessData(l *zerolog.Logger) (err error) {
 
 	// Get valid samples
-	validIdx, err := record.CircBuffer.GetBufferValidIndexes(l)
+	validIdx, err := record.CircBuffer.GetBufferValidIndexes(NumericalSampleTTLDays, l)
 	if err != nil {
 		return err
 	}
@@ -1191,10 +1196,15 @@ func (record *SignatureTaskRecord) GetNumOkSamples() uint32 {
 	// Initialize a counter for the number of OK samples
 	var okSamples uint32 = 0
 
+	maxAge := time.Duration(record.GetSampleTTLDays()) * 24 * time.Hour
 	// Loop through all the elements of `Signatures` and count the number that have `StatusCode==0`
 	// and checking if the element index is within the valid range using the function "IsIndexInRange(uint32)"
+	// and that the sample is not past its TTL.
 	for i, sample := range record.Signatures {
-		if record.CircBuffer.IsIndexInRange(uint32(i)) && sample.StatusCode == 0 {
+		idx := uint32(i)
+		if record.CircBuffer.IsIndexInRange(idx) && sample.StatusCode == 0 &&
+			record.CircBuffer.Times[idx] != types.EpochStart &&
+			time.Since(record.CircBuffer.Times[idx]) < maxAge {
 			okSamples++
 		}
 	}
@@ -1276,4 +1286,89 @@ func (record *SignatureTaskRecord) ProcessData(l *zerolog.Logger) (err error) {
 func (record *SignatureTaskRecord) GetResultStruct() ResultInterface {
 	var thisTaskResults SignatureResultRecord
 	return &thisTaskResults
+}
+
+// GetAllTasksForSupplier retrieves all existing task buffer records for a given
+// supplier from both buffers_numerical and buffers_signatures collections and
+// returns them grouped as TestsData per framework.
+func GetAllTasksForSupplier(
+	supplierID primitive.ObjectID,
+	mongoDB mongodb.MongoDb,
+	l *zerolog.Logger) ([]types.TestsData, error) {
+
+	// Set mongo context
+	ctxM, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Helper map: framework -> set of tasks
+	taskMap := make(map[string]map[string]struct{})
+
+	// -------------------------------------------------------------------------
+	// Query numerical buffers
+	// -------------------------------------------------------------------------
+	numCollection := mongoDB.GetCollection(types.NumericalTaskCollection)
+	numFilter := bson.D{{Key: "task_data.supplier_id", Value: supplierID}}
+	numCursor, err := numCollection.Find(ctxM, numFilter)
+	if err != nil {
+		l.Error().Err(err).Str("supplier_id", supplierID.String()).Msg("Could not retrieve numerical tasks from MongoDB.")
+		return nil, err
+	}
+	defer numCursor.Close(ctxM)
+
+	for numCursor.Next(ctxM) {
+		var record NumericalTaskRecord
+		if err := numCursor.Decode(&record); err != nil {
+			l.Error().Err(err).Str("supplier_id", supplierID.String()).Msg("Could not decode numerical task from MongoDB.")
+			return nil, err
+		}
+		fw := record.TaskData.Framework
+		task := record.TaskData.Task
+		if _, ok := taskMap[fw]; !ok {
+			taskMap[fw] = make(map[string]struct{})
+		}
+		taskMap[fw][task] = struct{}{}
+	}
+
+	// -------------------------------------------------------------------------
+	// Query signature buffers
+	// -------------------------------------------------------------------------
+	sigCollection := mongoDB.GetCollection(types.SignaturesTaskCollection)
+	sigFilter := bson.D{{Key: "task_data.supplier_id", Value: supplierID}}
+	sigCursor, err := sigCollection.Find(ctxM, sigFilter)
+	if err != nil {
+		l.Error().Err(err).Str("supplier_id", supplierID.String()).Msg("Could not retrieve signature tasks from MongoDB.")
+		return nil, err
+	}
+	defer sigCursor.Close(ctxM)
+
+	for sigCursor.Next(ctxM) {
+		var record SignatureTaskRecord
+		if err := sigCursor.Decode(&record); err != nil {
+			l.Error().Err(err).Str("supplier_id", supplierID.String()).Msg("Could not decode signature task from MongoDB.")
+			return nil, err
+		}
+		fw := record.TaskData.Framework
+		task := record.TaskData.Task
+		if _, ok := taskMap[fw]; !ok {
+			taskMap[fw] = make(map[string]struct{})
+		}
+		taskMap[fw][task] = struct{}{}
+	}
+
+	// -------------------------------------------------------------------------
+	// Convert map to []TestsData
+	// -------------------------------------------------------------------------
+	var results []types.TestsData
+	for fw, tasks := range taskMap {
+		taskList := make([]string, 0, len(tasks))
+		for t := range tasks {
+			taskList = append(taskList, t)
+		}
+		results = append(results, types.TestsData{
+			Framework: fw,
+			Tasks:     taskList,
+		})
+	}
+
+	return results, nil
 }

--- a/apps/go/manager/types/activities.go
+++ b/apps/go/manager/types/activities.go
@@ -75,3 +75,36 @@ type AnalyzeResultParams struct {
 type AnalyzeResultResults struct {
 	Success bool `json:"success"`
 }
+
+//------------------------------------------------------------------------------
+// Get All Suppliers
+//------------------------------------------------------------------------------
+
+type GetAllSuppliersResults struct {
+	Suppliers []SupplierData `json:"suppliers"`
+}
+
+//------------------------------------------------------------------------------
+// Update Supplier Buffers
+//------------------------------------------------------------------------------
+
+type UpdateSupplierBuffersParams struct {
+	Supplier SupplierData `json:"supplier"`
+	Tests    []TestsData  `json:"tests"`
+}
+
+type UpdateSupplierBuffersResults struct {
+	Success bool `json:"success"`
+}
+
+//------------------------------------------------------------------------------
+// Get Supplier Tests
+//------------------------------------------------------------------------------
+
+type GetSupplierTestsParams struct {
+	Supplier SupplierData `json:"supplier"`
+}
+
+type GetSupplierTestsResults struct {
+	Tests []TestsData `json:"tests"`
+}

--- a/apps/go/manager/types/circular_buffer.go
+++ b/apps/go/manager/types/circular_buffer.go
@@ -165,7 +165,14 @@ func (buffer *CircularBuffer) CycleIndexes(sampleTTLDays uint32, l *zerolog.Logg
 		oldestAge = time.Since(buffer.Times[buffer.Indexes.Start])
 		// Break if met the limit
 		if buffer.Indexes.Start == buffer.Indexes.End {
-			l.Debug().Msg("Circular buffer collapsed.")
+			if oldestAge >= maxAge {
+				l.Debug().Msg("Circular buffer collapsed (Zero valid samples).")
+				// Invalidate this sample
+				buffer.Times[buffer.Indexes.Start] = EpochStart
+				buffer.NumSamples = 0
+			} else {
+				l.Debug().Msg("Circular buffer collapsed (One valid sample).")
+			}
 			break
 		}
 	}
@@ -186,12 +193,13 @@ func (buffer *CircularBuffer) BufferLimitCheck(nextVal uint32, l *zerolog.Logger
 	return nextVal, nil
 }
 
-func (buffer *CircularBuffer) GetBufferValidIndexes(l *zerolog.Logger) (auxIdx []uint32, err error) {
+func (buffer *CircularBuffer) GetBufferValidIndexes(sampleTTLDays uint32, l *zerolog.Logger) (auxIdx []uint32, err error) {
 
+	maxAge := time.Duration(sampleTTLDays) * 24 * time.Hour
 	idxNow := buffer.Indexes.Start
 	for true {
-		// If the sample never written, we should ignore it
-		if buffer.Times[idxNow] != EpochStart {
+		// If the sample was never written or it is past TTL, we should ignore it
+		if buffer.Times[idxNow] != EpochStart && time.Since(buffer.Times[idxNow]) < maxAge {
 			// Add sample to data array
 			auxIdx = append(auxIdx, idxNow)
 		}

--- a/apps/go/manager/types/workflows.go
+++ b/apps/go/manager/types/workflows.go
@@ -40,3 +40,11 @@ type ResultAnalyzerParams struct {
 type ResultAnalyzerResults struct {
 	Success bool `json:"success"`
 }
+
+type SupplierBufferUpdaterParams struct {
+}
+
+type SupplierBufferUpdaterResults struct {
+	ProcessedSuppliers uint `json:"processed_suppliers"`
+	FailedSuppliers    uint `json:"failed_suppliers"`
+}

--- a/apps/go/manager/workflows/entry.go
+++ b/apps/go/manager/workflows/entry.go
@@ -43,4 +43,11 @@ func (wCtx *Ctx) Register(w worker.Worker) {
 	w.RegisterWorkflowWithOptions(wCtx.ResultAnalyzer, workflow.RegisterOptions{
 		Name: ResultAnalyzerName,
 	})
+
+	// Background workflow that cycles buffers for all existing DB suppliers
+	// without triggering new tasks. Ensures stale samples are flushed even
+	// when a supplier is no longer returned by the staked-suppliers source.
+	w.RegisterWorkflowWithOptions(wCtx.SupplierBufferUpdater, workflow.RegisterOptions{
+		Name: SupplierBufferUpdaterName,
+	})
 }

--- a/apps/go/manager/workflows/supplier_buffer_updater.go
+++ b/apps/go/manager/workflows/supplier_buffer_updater.go
@@ -1,0 +1,139 @@
+package workflows
+
+import (
+	"fmt"
+	"time"
+
+	"manager/activities"
+	"manager/types"
+
+	"go.temporal.io/sdk/workflow"
+)
+
+var SupplierBufferUpdaterName = "SupplierBufferUpdater"
+
+// SupplierBufferUpdater - Is a workflow that loops over all existing suppliers
+// in the database and updates their circular buffers (dropping stale samples)
+// without triggering any new evaluation tasks.
+func (wCtx *Ctx) SupplierBufferUpdater(ctx workflow.Context, params types.SupplierBufferUpdaterParams) (*types.SupplierBufferUpdaterResults, error) {
+
+	l := wCtx.App.Logger
+	l.Debug().Msg("Starting Supplier Buffer Updater Workflow.")
+
+	// Create result
+	result := types.SupplierBufferUpdaterResults{}
+
+	// -------------------------------------------------------------------------
+	// -------------------- Get all suppliers from DB --------------------------
+	// -------------------------------------------------------------------------
+	ctxTimeout := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    time.Minute * 5,
+	})
+
+	var allSuppliers types.GetAllSuppliersResults
+	err := workflow.ExecuteActivity(ctxTimeout, activities.GetAllSuppliersName).Get(ctx, &allSuppliers)
+	if err != nil {
+		return &result, err
+	}
+
+	l.Debug().Int("supplierCount", len(allSuppliers.Suppliers)).Msg("Loaded suppliers from DB.")
+
+	// -------------------------------------------------------------------------
+	// Phase 1: Discover existing tasks for each supplier
+	// -------------------------------------------------------------------------
+	ctxTimeout = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    time.Minute,
+	})
+
+	selector := workflow.NewSelector(ctx)
+
+	type supplierTestsChanItem struct {
+		Supplier types.SupplierData
+		Tests    []types.TestsData
+	}
+
+	supplierTestsChan := make(chan supplierTestsChanItem, len(allSuppliers.Suppliers))
+	defer close(supplierTestsChan)
+
+	for _, supplier := range allSuppliers.Suppliers {
+		supplier := supplier // capture loop variable for closure
+		res := types.GetSupplierTestsResults{}
+		selector.AddFuture(
+			workflow.ExecuteActivity(
+				ctxTimeout,
+				activities.GetSupplierTestsName,
+				types.GetSupplierTestsParams{Supplier: supplier},
+			),
+			func(f workflow.Future) {
+				err := f.Get(ctx, &res)
+				if err != nil {
+					return
+				}
+				supplierTestsChan <- supplierTestsChanItem{
+					Supplier: supplier,
+					Tests:    res.Tests,
+				}
+			},
+		)
+	}
+
+	supplierTestsMap := make(map[string][]types.TestsData)
+	for i := 0; i < len(allSuppliers.Suppliers); i++ {
+		selector.Select(ctx)
+		item := <-supplierTestsChan
+		key := fmt.Sprintf("%s|%s", item.Supplier.Address, item.Supplier.Service)
+		supplierTestsMap[key] = item.Tests
+	}
+
+	// -------------------------------------------------------------------------
+	// Phase 2: Update buffers for each supplier using discovered tests
+	// -------------------------------------------------------------------------
+	ctxTimeout = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    time.Minute,
+	})
+
+	selector = workflow.NewSelector(ctx)
+
+	supplierUpdateResultsChan := make(chan types.UpdateSupplierBuffersResults, len(allSuppliers.Suppliers))
+	defer close(supplierUpdateResultsChan)
+
+	for _, supplier := range allSuppliers.Suppliers {
+		supplier := supplier // capture loop variable for closure
+		key := fmt.Sprintf("%s|%s", supplier.Address, supplier.Service)
+		tests := supplierTestsMap[key]
+
+		res := types.UpdateSupplierBuffersResults{}
+		selector.AddFuture(
+			workflow.ExecuteActivity(
+				ctxTimeout,
+				activities.UpdateSupplierBuffersName,
+				types.UpdateSupplierBuffersParams{
+					Supplier: supplier,
+					Tests:    tests,
+				},
+			),
+			func(f workflow.Future) {
+				err := f.Get(ctx, &res)
+				if err != nil {
+					return
+				}
+				supplierUpdateResultsChan <- res
+			},
+		)
+	}
+
+	for i := 0; i < len(allSuppliers.Suppliers); i++ {
+		selector.Select(ctx)
+		response := <-supplierUpdateResultsChan
+		if response.Success {
+			result.ProcessedSuppliers += 1
+		} else {
+			result.FailedSuppliers += 1
+		}
+	}
+
+	return &result, nil
+}

--- a/tilt/trigger_tasks.py
+++ b/tilt/trigger_tasks.py
@@ -95,6 +95,40 @@ def schedule_snapshot_task(interval="24h", execution_timeout=1200, task_timeout=
     return run_command(command)
 
 
+def schedule_buffer_updater_task(
+    interval="12h", execution_timeout=1200, task_timeout=1200
+):
+    command = BASE_COMMAND + [
+        "--",
+        "temporal",
+        "schedule",
+        "create",
+        "--schedule-id",
+        "supplier-buffer-updater",
+        "--workflow-id",
+        "supplier-buffer-updater",
+        "--type",
+        "SupplierBufferUpdater",
+        "--task-queue",
+        "manager",
+        "--interval",
+        f"{interval}",
+        "--overlap-policy",
+        "Skip",
+        "--catchup-window",
+        "1s",
+        "--execution-timeout",
+        f"{execution_timeout}s",
+        "--run-timeout",
+        f"{execution_timeout}s",
+        "--task-timeout",
+        f"{task_timeout}s",
+        "--namespace",
+        f"{TEMPORAL_NAMESPACE}",
+    ]
+    return run_command(command)
+
+
 def schedule_summary_task(interval="1h", execution_timeout=1200, task_timeout=1200):
     command = BASE_COMMAND + [
         "--",
@@ -475,6 +509,12 @@ def main():
         help="Interval for snapshot tasks (default: 24h)",
     )
     parser.add_argument(
+        "--buffer-updater-interval",
+        type=validate_interval,
+        default="12h",
+        help="Interval for buffer updater tasks (default: 1h)",
+    )
+    parser.add_argument(
         "--phase-offset",
         type=int,
         default=0,
@@ -492,6 +532,7 @@ def main():
     lookup_interval = args.lookup_interval
     summary_interval = args.summary_interval
     snapshot_interval = args.snapshot_interval
+    buffer_updater_interval = args.buffer_updater_interval
     phase_offset = args.phase_offset
 
     # Validate taxonomy if provided
@@ -693,6 +734,12 @@ def main():
 
         schedule_snapshot_task(
             interval=snapshot_interval, execution_timeout=1200, task_timeout=1200
+        )
+        print("Snapshot scheduled.")
+        time.sleep(0.25)
+
+        schedule_buffer_updater_task(
+            interval=buffer_updater_interval, execution_timeout=1200, task_timeout=1200
         )
         print("Snapshot scheduled.")
         time.sleep(0.25)


### PR DESCRIPTION
# Background Buffer Updater & Circular Buffer Collapse Fixes
### Problem
When a supplier unstakes (or is removed from `ExternalSuppliers`), the `SupplierManager` workflow stops calling `AnalyzeSupplier` for that supplier. Since `AnalyzeSupplier` is the only place where circular buffers are cycled (old samples dropped, indices moved), the buffers for removed suppliers hold **stale data forever** — metrics reflect expired samples and new tasks may never be triggered because `GetNumOkSamples` counts stale data.
### Solution
This PR introduces a **new background workflow** that updates circular buffers for *all* existing DB suppliers independently of the staked-supplier list, and fixes several bugs in the circular buffer lifecycle.
### New Workflow: `SupplierBufferUpdater`
A standalone Temporal workflow that:
1. Queries **all suppliers** from MongoDB
2. **Discovers each supplier's existing tasks** by scanning `buffers_numerical` and `buffers_signatures`
3. Cycles those buffers and drops stale samples
4. **Does NOT trigger new evaluation tasks** — this is purely maintenance
**Files added:**
- `apps/go/manager/workflows/supplier_buffer_updater.go` — two-phase fan-out workflow (Phase 1: discover tests via `GetSupplierTests`, Phase 2: update buffers via `UpdateSupplierBuffers`)
- `apps/go/manager/activities/get_supplier_tests.go` — activity that loads a supplier and discovers its existing tasks from DB
- `apps/go/manager/activities/update_supplier_buffers.go` — activity that cycles buffers for a single supplier
- `apps/go/manager/activities/get_all_suppliers.go` — activity that returns all suppliers from DB
**Files modified:**
- `apps/go/manager/types/workflows.go` — added `SupplierBufferUpdaterParams` / `SupplierBufferUpdaterResults`
- `apps/go/manager/types/activities.go` — added `GetSupplierTestsParams` / `GetSupplierTestsResults`, `UpdateSupplierBuffersParams` / `UpdateSupplierBuffersResults`
- `apps/go/manager/activities/entry.go` — registered new activities
- `apps/go/manager/workflows/entry.go` — registered new workflow
- `tilt/trigger_tasks.py` — added `schedule_buffer_updater_task()` for manual Temporal scheduling
### Refactoring: Extract `UpdateSupplierData`
The buffer-update logic (lines 55–100 of `AnalyzeSupplier`) was extracted into a standalone function `UpdateSupplierData(...)` in `activities/analyze_supplier.go`. Both `AnalyzeSupplier` and `UpdateSupplierBuffers` now call this shared function.
### Bug Fix: Re-calculate Metrics After Buffer Cycling
`updateTasksSupplier` now calls `thisTaskRecord.ProcessData(l)` after `CycleIndexes(l)` and before saving to MongoDB. This ensures that derived metrics (`MeanScore`, `ErrorRate`, `LastSignature`, etc.) are recalculated to reflect only the **remaining valid samples**.
### Bug Fix: Circular Buffer Collapse Edge Cases
**`CycleIndexes` — proper collapse handling**
- When the buffer collapses to a single index, the remaining stale sample is now stamped with `EpochStart`
- `NumSamples` is set to `0` so the buffer is semantically identical to a fresh buffer
- Collapse only occurs if the remaining sample is actually past TTL (previously it would stamp even a fresh remaining sample)
**`GetBufferValidIndexes` — TTL-aware**
- Now accepts a `sampleTTLDays` parameter
- Skips samples past TTL in addition to `EpochStart` slots
- This prevents `ProcessData` from computing metrics using expired data
**`GetNumOkSamples` — TTL-aware (both Numerical & Signature)**
- Now checks `Times[idx] != EpochStart` and `time.Since(Times[idx]) < maxAge`
- This prevents `AnalyzeSupplier` from skipping task triggers because stale OK samples were counted